### PR TITLE
Remove -f (force) argument from reboot commands

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
  - RTC 530033 - Add AOTA Applicaiton Update command to INBC
 
+### Fixed
+ - RTC 530482 - Remove 'force' option in OTA's
+
 ## 4.0.1 - 2023-05-26
  - RTC 529914 - Implement OTA logger
 

--- a/inbm/dispatcher-agent/dispatcher/aota/application_command.py
+++ b/inbm/dispatcher-agent/dispatcher/aota/application_command.py
@@ -217,7 +217,7 @@ class UbuntuApplication(Application):
         if code != 0:
             raise AotaError(err)
 
-        reboot_base_command = "/sbin/reboot -f"
+        reboot_base_command = "/sbin/reboot"
         if is_docker_app:
             reboot_command = DOCKER_CHROOT_PREFIX + reboot_base_command
         else:

--- a/inbm/dispatcher-agent/dispatcher/sota/rebooter.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/rebooter.py
@@ -45,7 +45,7 @@ class LinuxRebooter(Rebooter):
         super().reboot()
         is_docker_app = os.environ.get("container", False)
 
-        cmd = "/sbin/reboot -f"
+        cmd = "/sbin/reboot"
         if is_docker_app:
             logger.debug("APP ENV : {}".format(is_docker_app))
             (output, err, code) = PseudoShellRunner.run(DOCKER_CHROOT_PREFIX + cmd)


### PR DESCRIPTION
The purpose of this PR is to remove the -f (force) argument from reboot commands in
INBM. Sometimes -f can cause problems with some systems coming back up from reboot.