### PR TITLE
(53217) Fix [TC-Base][Bug] Cloudadapter cannot connect to Azure

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
  - RTC 531066 - [TC Base] [Bug] Cloud Adapter disconnected upon provisioned
+ - RTC 532217 - [TC Base] [Bug] Cloud Adapter cannot connect to Azure
 
 ## 4.1.1 - 2023-06-23
 

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/client/connections/mqtt_connection.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/client/connections/mqtt_connection.py
@@ -20,9 +20,9 @@ import socks
 import logging
 logger = logging.getLogger(__name__)
 
-MAX_STRING_CHARS = 50
+MAX_STRING_CHARS = 2048
 MAX_PORT_LENGTH = 7
-MAX_CLIENT_ID_LENGTH = 35
+MAX_CLIENT_ID_LENGTH = 500
 
 
 class MQTTConnection(Connection):
@@ -54,16 +54,16 @@ class MQTTConnection(Connection):
 
         if len(username) > MAX_STRING_CHARS:
             raise ValueError(
-                f"{username} is too long.  Must be less than {MAX_STRING_CHARS} in length.")
+                f"username {username} is too long.  Must be less than {MAX_STRING_CHARS} in length.")
         if password and len(password) > MAX_STRING_CHARS:
             raise ValueError(
-                f"{password} is too long.  Must be less than {MAX_STRING_CHARS} in length")
+                f"password is too long.  Must be less than {MAX_STRING_CHARS} in length")
         if len(hostname) > MAX_STRING_CHARS:
             raise ValueError(
-                f"{hostname} is too long.  Must be less than {MAX_STRING_CHARS} in length")
+                f"hostname {hostname} is too long.  Must be less than {MAX_STRING_CHARS} in length")
         if client_id and len(client_id) > MAX_CLIENT_ID_LENGTH:
             raise ValueError(
-                f"{client_id} is too long.  Must be less than {MAX_CLIENT_ID_LENGTH} in length")
+                f"client_id {client_id} is too long.  Must be less than {MAX_CLIENT_ID_LENGTH} in length")
 
         self._username = username
         self._password = password

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/cloud_builders.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/cloud_builders.py
@@ -117,7 +117,7 @@ def build_client_with_config(config: Dict[str, Any]) -> CloudClient:
                 tls_config=tls_config,
                 proxy_config=proxy_config)
         except (ValueError, ConnectError, OSError, FileNotFoundError) as e:
-            raise ClientBuildError(f"Error creating MQTT Connection: {e}")
+            raise ClientBuildError(f"Error creating MQTT Connection") from e
     else:
         raise ClientBuildError(
             "Missing MQTT config information while setting up cloud connection.")


### PR DESCRIPTION
Cloudadapter is unable to create an mqtt connection because of a hardcoded string length limit. This change relaxes that limit.