### PR TITLE
Add firmware update database entry for NUC12WSHv5

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## NEXT - ?
 
 ### Fixed
-- RTC 533936 - [INBM] Fix sota Kernel upgrade failure
+ - RTC 533936 - [INBM] Fix sota Kernel upgrade failure
 
 ### Added
+ - Add firmware update database entry for NUC12WSHv5 using /usr/bin/iFlashVLnx64. This tool can be downloaded from https://www.intel.com/content/www/us/en/download/19504/intel-aptio-v-uefi-firmware-integrator-tools-for-intel-nuc.html
+
 ### Security
-- dependabot: update cryptography from 41.0.3 to 41.0.4
+ - dependabot: update cryptography from 41.0.3 to 41.0.4
 
 ## 4.1.3 - 2023-09-05
 

--- a/inbm/dispatcher-agent/fpm-template/etc/firmware_tool_info.conf
+++ b/inbm/dispatcher-agent/fpm-template/etc/firmware_tool_info.conf
@@ -106,6 +106,12 @@
 	<firmware_tool_args>/usr/bin/SblFwUpdate.py</firmware_tool_args>
         <firmware_file_type>xx</firmware_file_type>
     </firmware_product>
+    <firmware_product name='NUC12WSHv5'>
+        <bios_vendor>Intel Corp.</bios_vendor>
+        <operating_system>linux</operating_system>
+        <firmware_tool>/usr/bin/iFlashVLnx64</firmware_tool>
+        <firmware_file_type>cap</firmware_file_type>
+    </firmware_product>
 </firmware_component>
 
 

--- a/inbm/packaging/yocto/ehl/firmware_tool_info.conf
+++ b/inbm/packaging/yocto/ehl/firmware_tool_info.conf
@@ -99,6 +99,12 @@
         <firmware_tool>afulnx_64</firmware_tool>
         <firmware_file_type>xx</firmware_file_type>
     </firmware_product>
+    <firmware_product name='NUC12WSHv5'>
+        <bios_vendor>Intel Corp.</bios_vendor>
+        <operating_system>linux</operating_system>
+        <firmware_tool>/usr/bin/iFlashVLnx64</firmware_tool>
+        <firmware_file_type>cap</firmware_file_type>
+    </firmware_product>
 </firmware_component>
 
 

--- a/inbm/packaging/yocto/kmb/firmware_tool_info.conf
+++ b/inbm/packaging/yocto/kmb/firmware_tool_info.conf
@@ -99,6 +99,12 @@
         <firmware_tool>afulnx_64</firmware_tool>
         <firmware_file_type>xx</firmware_file_type>
     </firmware_product>
+        <firmware_product name='NUC12WSHv5'>
+        <bios_vendor>Intel Corp.</bios_vendor>
+        <operating_system>linux</operating_system>
+        <firmware_tool>/usr/bin/iFlashVLnx64</firmware_tool>
+        <firmware_file_type>cap</firmware_file_type>
+    </firmware_product>
 </firmware_component>
 
 


### PR DESCRIPTION
This is using /usr/bin/iFlashVLnx64. This tool can be downloaded from https://www.intel.com/content/www/us/en/download/19504/intel-aptio-v-uefi-firmware-integrator-tools-for-intel-nuc.html
