### PR TITLE
Convert from nose to pytest

### DIFF
--- a/inbc-program/.gitignore
+++ b/inbc-program/.gitignore
@@ -3,7 +3,6 @@ pyproject.toml
 # Unit test / coverage reports
 .coverage
 .coverage.*
-nosetests.xml
 coverage.xml
 *.cover
 **/cover/

--- a/inbc-program/Makefile
+++ b/inbc-program/Makefile
@@ -17,7 +17,7 @@ run:
 	sudo PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(PROGRAM).$(PROGRAM) $(COMMAND_TO_TRIGGER)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x nosetests --with-coverage --cover-erase --cover-inclusive --cover-html --cover-package=$(PROGRAM)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(PROGRAM) --cov-report=term-missing tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm-lib/inbm_lib/.gitignore
+++ b/inbm-lib/inbm_lib/.gitignore
@@ -1,6 +1,5 @@
 # Unit test / coverage reports
 .coverage
 .coverage.*
-nosetests.xml
 coverage.xml
 *.cover

--- a/inbm-lib/inbm_lib/mqttclient/.gitignore
+++ b/inbm-lib/inbm_lib/mqttclient/.gitignore
@@ -1,6 +1,5 @@
 # Unit test / coverage reports
 .coverage
 .coverage.*
-nosetests.xml
 coverage.xml
 *.cover

--- a/inbm-lib/setup.py
+++ b/inbm-lib/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 with open('README.md') as f:
     readme = f.read()
 
-test_deps = ['mock==4.0.2', 'pynose==1.4.8', 'testtools==2.5.0', 'ddt==1.2.1']
+test_deps = ['mock==4.0.2', 'pytest==7.4.3', 'testtools==2.5.0', 'ddt==1.2.1']
 extras = {
     'test': test_deps,
 }
@@ -16,7 +16,7 @@ setup(
     packages=['inbm_lib', 'inbm_common_lib'],
     include_package_data=True,
     install_requires=['paho-mqtt==1.5.1', 'dmidecode==0.9.0', 'xmlschema==1.5.3', 'defusedxml==0.7.1', 'future==0.18.3', 'url-normalize==1.4.3', 'snoop==0.4.3'],
-    test_suite='nose.collector',
+    test_suite='pytest',
     tests_require=test_deps,
     extras_require=extras,
     package_data = { 'inbm_lib': ['py.typed'], 'inbm_common_lib': ['py.typed']}

--- a/inbm/.gitignore
+++ b/inbm/.gitignore
@@ -14,7 +14,6 @@ arm_rpms/
 paho.mqtt.python/
 **/__pycache__
 **/*.pyc
-**/.noseids
 **/.mypy_cache/
 .coverage
 **/.pytype/

--- a/inbm/cloudadapter-agent/.gitignore
+++ b/inbm/cloudadapter-agent/.gitignore
@@ -39,7 +39,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/inbm/cloudadapter-agent/Makefile
+++ b/inbm/cloudadapter-agent/Makefile
@@ -35,7 +35,7 @@ run:
 	PYTHONDONTWRITEBYTECODE=x PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(AGENT).$(AGENT)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x pynose --with-coverage --cover-erase --cover-inclusive --cover-package=$(AGENT)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(AGENT) --cov-report=term-missing tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm/cloudadapter-agent/setup.py
+++ b/inbm/cloudadapter-agent/setup.py
@@ -14,6 +14,6 @@ setup(
     license='Intel Proprietary (see \'licenses\' directory)',
     packages=find_packages(exclude=['*.*', 'mqttclient']),
     include_package_data=True,
-    install_requires=['pynose', 'packaging', 'future'],
-    test_suite='nose.collector',
-    tests_require=['pynose'])
+    install_requires=['pytest', 'pytest-cov' 'packaging', 'future'],
+    test_suite='pytest',
+    tests_require=['pytest', 'pytest-cov'])

--- a/inbm/cloudadapter-agent/test-requirements.txt
+++ b/inbm/cloudadapter-agent/test-requirements.txt
@@ -1,7 +1,8 @@
 #Pre-Production
 
 mock==5.0.2
-pynose==1.4.8
+pytest==7.4.3
+pytest-cov==4.1.0
 packaging==20.9
 ddt==1.4.2
 testtools==2.5.0

--- a/inbm/configuration-agent/.gitignore
+++ b/inbm/configuration-agent/.gitignore
@@ -42,7 +42,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/inbm/configuration-agent/Makefile
+++ b/inbm/configuration-agent/Makefile
@@ -33,7 +33,7 @@ run:
 	PYTHONDONTWRITEBYTECODE=x PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(AGENT).$(AGENT)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x pynose --with-coverage --cover-erase --cover-inclusive --cover-tests --cover-package=$(AGENT)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(AGENT) --cov-report=term-missing configuration/tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm/configuration-agent/setup.py
+++ b/inbm/configuration-agent/setup.py
@@ -11,6 +11,6 @@ setup(
     license='Intel Proprietary (see \'licenses\' directory)',
     packages=find_packages(exclude=['*.*', 'mqttclient']),
     include_package_data=True,
-    install_requires=['pynose', 'packaging', 'future'],
-    test_suite='nose.collector',
-    tests_require=['pynose'])
+    install_requires=['pytest', 'pytest-cov' 'packaging', 'future'],
+    test_suite='pytest',
+    tests_require=['pytest', 'pytest-cov'])

--- a/inbm/configuration-agent/test-requirements.txt
+++ b/inbm/configuration-agent/test-requirements.txt
@@ -1,6 +1,7 @@
 #Pre-Production
 mock==4.0.3
-pynose==1.4.8
+pytest==7.4.3
+pytest-cov==4.1.0
 packaging==20.9
 ddt==1.4.2
 testtools==2.5.0

--- a/inbm/diagnostic-agent/.gitignore
+++ b/inbm/diagnostic-agent/.gitignore
@@ -40,7 +40,6 @@ htmlcov/
 .coverage.*
 .coveragerc
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/inbm/diagnostic-agent/Makefile
+++ b/inbm/diagnostic-agent/Makefile
@@ -31,7 +31,7 @@ run:
 	PYTHONDONTWRITEBYTECODE=x PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(AGENT).$(AGENT)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x pynose --with-coverage --cover-erase --cover-inclusive --cover-html --cover-package=$(AGENT)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(AGENT) --cov-report=term-missing tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm/diagnostic-agent/setup.py
+++ b/inbm/diagnostic-agent/setup.py
@@ -11,7 +11,7 @@ setup(
     license='Intel Proprietary (see \'licenses\' directory)',
     packages=find_packages(exclude=['*.*', 'mqttclient']),
     include_package_data=True,
-    install_requires=['mock', 'pynose', 'packaging', 'future'],
-    test_suite='nose.collector',
-    tests_require=['pynose']
+    install_requires=['mock', 'pytest', 'pytest-cov' 'packaging', 'future'],
+    test_suite='pytest',
+    tests_require=['pytest', 'pytest-cov']
 )

--- a/inbm/diagnostic-agent/test-requirements.txt
+++ b/inbm/diagnostic-agent/test-requirements.txt
@@ -2,7 +2,8 @@
 mock==4.0.3
 ddt==1.4.2
 testtools==2.5.0
-pynose==1.4.8
+pytest==7.4.3
+pytest-cov==4.1.0
 packaging==20.9
 coverage==5.5
 

--- a/inbm/dispatcher-agent/.gitignore
+++ b/inbm/dispatcher-agent/.gitignore
@@ -39,7 +39,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/inbm/dispatcher-agent/Makefile
+++ b/inbm/dispatcher-agent/Makefile
@@ -32,7 +32,7 @@ run:
 	PYTHONDONTWRITEBYTECODE=x PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(AGENT).$(AGENT)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x pynose --with-coverage --cover-erase --cover-inclusive --cover-html --cover-package=$(AGENT)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(AGENT) --cov-report=term-missing tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
+++ b/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
@@ -773,10 +773,10 @@ class Dispatcher:
             self._install_check_service.install_check(check_type='swCheck', size=0)
             self._install_check_service.install_check(check_type='check_network', size=0)
             self._telemetry('On Boot, Diagnostics reports healthy system')
-            logger.info("On Boot, Diagnostics reports healthy system") 
+            logger.info("On Boot, Diagnostics reports healthy system")
             self.invoke_sota(action='diagnostic_system_healthy', snapshot=None)
             self._update_logger.update_log(OTA_SUCCESS)
-            logger.info(OTA_SUCCESS) 
+            logger.info(OTA_SUCCESS)
         except DispatcherException:
             self._telemetry(
                 'On Boot, Diagnostics reports some services not up after previous SOTA')

--- a/inbm/dispatcher-agent/setup.py
+++ b/inbm/dispatcher-agent/setup.py
@@ -10,8 +10,8 @@ setup(
     license='Intel Proprietary (see \'licenses\' directory)',
     packages=find_packages(exclude=['tests.*', '*.tests.*', 'tests', '*.tests', 'test_*']),
     include_package_data=True,
-    install_requires=['mock', 'pynose', 'packaging',
+    install_requires=['mock', 'pytest', 'pytest-cov', 'packaging',
                       'future', 'paho-mqtt', 'jsonschema', 'cryptography'],
-    test_suite='nose.collector',
-    tests_require=['pynose']
+    test_suite='pytest',
+    tests_require=['pytest', 'pytest-cov']
 )

--- a/inbm/dispatcher-agent/test-requirements.txt
+++ b/inbm/dispatcher-agent/test-requirements.txt
@@ -2,7 +2,8 @@
 ddt==1.4.2
 fixtures==3.0.0
 mock==4.0.3
-pynose==1.4.8
+pytest==7.4.3
+pytest-cov==4.1.0
 packaging==20.9
 testtools==2.5.0
 requests_mock==1.8.0

--- a/inbm/dispatcher-agent/tests/unit/common/mock_resources.py
+++ b/inbm/dispatcher-agent/tests/unit/common/mock_resources.py
@@ -350,6 +350,6 @@ class MockInstallCheckService(InstallCheckService):
         self._install_check_called = True
         if not self._install_check:
             raise DispatcherException('MockInstallCheckService set to fail install check')
-    
+
     def install_check_called(self) -> bool:
         return self._install_check_called

--- a/inbm/dispatcher-agent/tests/unit/test_dispatcher.py
+++ b/inbm/dispatcher-agent/tests/unit/test_dispatcher.py
@@ -59,7 +59,7 @@ class TestDispatcher(TestCase):
                              m_sub: Any,
                              m_connect: Any,
                              m_thread_start: Any,
-                             mock_logging: Any) -> None:        
+                             mock_logging: Any) -> None:
         xml = '<?xml version="1.0" encoding="UTF-8"?>' \
               '<manifest><type>ota</type><ota><header><id>sampleId</id><name>Sample FOTA</name><description>' \
               'Sample FOTA manifest file</description><type>aota</type><repository>remote</repository>' \
@@ -217,7 +217,8 @@ class TestDispatcher(TestCase):
                                    mock_logging: Any) -> None:
 
         xml = '<?xml version="1.0" encoding="UTF-8"?><manifest><type>config</type><config><cmd>set_element</cmd><configtype><set><path>maxCacheSize:149</path></set></configtype></config></manifest>'
-        d = TestDispatcher._build_dispatcher(install_check=MockInstallCheckService(install_check=True))
+        d = TestDispatcher._build_dispatcher(
+            install_check=MockInstallCheckService(install_check=True))
         mock_request_config_agent.return_value = True
         self.assertEquals(200, d.do_install(xml=xml, schema_location=TEST_SCHEMA_LOCATION).status)
 
@@ -235,7 +236,8 @@ class TestDispatcher(TestCase):
                                    mock_logging: Any) -> None:
 
         xml = '<?xml version="1.0" encoding="UTF-8"?><manifest><type>config</type><config><cmd>set_element</cmd><configtype><set><path>"maxCacheSize":"149"</path></set></configtype></config></manifest>'
-        d = TestDispatcher._build_dispatcher(install_check=MockInstallCheckService(install_check=False))
+        d = TestDispatcher._build_dispatcher(
+            install_check=MockInstallCheckService(install_check=False))
         mock_request_config_agent.return_value = True
         self.assertEquals(400, d.do_install(xml=xml, schema_location=TEST_SCHEMA_LOCATION).status)
 

--- a/inbm/dockerfiles/Dockerfile-check.m4
+++ b/inbm/dockerfiles/Dockerfile-check.m4
@@ -15,7 +15,6 @@ RUN python3.11 -m venv /venv-py3
 RUN source /venv-py3/bin/activate && \
     pip3.11 install wheel==0.40.0 && \
     pip3.11 install \
-        pynose==1.4.8 \
         flake8==4.0.1 \
         bandit==1.7.3 \
         flake8-bandit==3.0.0 \
@@ -26,6 +25,9 @@ RUN source /venv-py3/bin/activate && \
         pylint==2.5.3 \
         mypy==1.3 \
         types-requests==2.31.0.1 \
+    	pytest==7.4.3 \
+    	pytest-cov==4.1.0 \
+        pytest-xdist==3.3.1 \
         -U
 COPY inbm-lib /src/inbm-lib
 ENV PYTHONPATH=/src/inbm-lib
@@ -50,7 +52,6 @@ RUN source /venv-py3/bin/activate && \
     ./mypy-py3.sh . && \
     touch /passed.txt
 
-
 FROM venv-py3 as test-inbm-lib
 WORKDIR /src/inbm-lib
 RUN source /venv-py3/bin/activate && \
@@ -58,9 +59,9 @@ RUN source /venv-py3/bin/activate && \
     set -o pipefail && \
     mkdir -p /output/coverage && \
     cd tests/unit && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=inbm_common_lib inbm_common_lib 2>&1 | tee /output/coverage/inbm-common-lib-coverage.txt && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=inbm_lib inbm_lib 2>&1 | tee /output/coverage/inbm-lib-coverage.txt && \
-    coverage report --show-missing --fail-under=82 && \
+    pytest -n 1 --cov=inbm_common_lib --cov-report=term-missing --cov-fail-under=82 inbm_common_lib 2>&1 | tee /output/coverage/inbm-common-lib-coverage.txt && \
+    pytest -n 1 --cov=inbm_lib --cov-report=term-missing --cov-fail-under=82 inbm_lib 2>&1 | tee /output/coverage/inbm-lib-coverage.txt && \
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
     touch /passed.txt
 
 # ---inbc---
@@ -88,8 +89,8 @@ FROM venv-inbc-py3 as inbc-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=inbc tests/unit 2>&1 | tee /output/coverage/inbc-coverage.txt && \
-    coverage report --fail-under=84
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 1 --cov=inbc --cov-report=term-missing --cov-fail-under=84 tests/unit 2>&1 | tee /output/coverage/inbc-coverage.txt
 
 # ---diagnostic agent---
 
@@ -117,8 +118,8 @@ FROM venv-diagnostic-py3 as diagnostic-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=diagnostic tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt && \
-    coverage report --fail-under=80
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 1 --cov=diagnostic --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt
 
 # ---dispatcher agent---
 
@@ -149,8 +150,8 @@ FROM venv-dispatcher-py3 as dispatcher-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=dispatcher tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt && \
-    coverage report --fail-under=80
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 10 --cov=dispatcher --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt
 
 # ---cloudadapter agent---
 
@@ -177,8 +178,8 @@ FROM venv-cloudadapter-py3 as cloudadapter-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=cloudadapter tests/unit 2>&1 | tee /output/coverage/cloudadapter-coverage.txt && \
-    coverage report --fail-under=90
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 10 --cov=cloudadapter --cov-report=term-missing --cov-fail-under=90 tests/unit 2>&1 | tee /output/coverage/cloudadapter-coverage.txt
 
 # ---telemetry agent---
 
@@ -205,8 +206,8 @@ FROM venv-telemetry-py3 as telemetry-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=telemetry telemetry/tests/unit 2>&1 | tee /output/coverage/telemetry-coverage.txt && \
-    coverage report --fail-under=83
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 1 --cov=telemetry --cov-report=term-missing --cov-fail-under=83 telemetry/tests/unit 2>&1 | tee /output/coverage/telemetry-coverage.txt
 
 # ---configuration agent---
 
@@ -233,8 +234,8 @@ FROM venv-configuration-py3 as configuration-unit-tests
 RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
-    pynose --with-coverage --cover-erase --cover-inclusive --cover-package=configuration configuration/tests/unit 2>&1 | tee /output/coverage/configuration-coverage.txt && \
-    coverage report --fail-under=88
+    export PYTHONPATH=$PYTHONPATH:$(pwd) && \
+    pytest -n 1 --cov=configuration --cov-report=term-missing --cov-fail-under=88 configuration/tests/unit 2>&1 | tee /output/coverage/configuration-coverage.txt
 
 # output container
 FROM base as output

--- a/inbm/telemetry-agent/.gitignore
+++ b/inbm/telemetry-agent/.gitignore
@@ -39,7 +39,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/

--- a/inbm/telemetry-agent/Makefile
+++ b/inbm/telemetry-agent/Makefile
@@ -28,7 +28,7 @@ run:
 	PYTHONDONTWRITEBYTECODE=x PYTHONPATH=$(LOCAL_PIP_PATH) python3 -m $(AGENT).$(AGENT)
 
 tests:
-	PYTHONDONTWRITEBYTECODE=x pynose --with-coverage --cover-erase --cover-inclusive --cover-tests --cover-package=$(AGENT)
+	PYTHONPATH="${PYTHONPATH}:$(shell pwd):$(shell pwd)/../../inbm-lib" PYTHONDONTWRITEBYTECODE=x pytest --cov=$(AGENT) --cov-report=term-missing telemetry/tests/unit
 
 deb-eval-py3:
 	./package-py3.sh deb EVAL

--- a/inbm/telemetry-agent/setup.py
+++ b/inbm/telemetry-agent/setup.py
@@ -11,7 +11,7 @@ setup(
     license='Apache 2.0',
     packages=find_packages(exclude=('tests', 'doc')),
     include_package_data=True,
-    install_requires=['pynose', 'packaging', 'future', 'paho-mqtt', 'psutil'],
-    test_suite='nose.collector',
-    tests_require=['pynose']
+    install_requires=['pytest', 'pytest-cov', 'packaging', 'future', 'paho-mqtt', 'psutil'],
+    test_suite='pytest',
+    tests_require=['pytest', 'pytest-cov']
 )

--- a/inbm/telemetry-agent/test-requirements.txt
+++ b/inbm/telemetry-agent/test-requirements.txt
@@ -2,7 +2,8 @@
 
 ddt==1.4.2
 mock==4.0.3
-pynose==1.4.8
+pytest==7.4.3
+pytest-cov==4.1.0
 packaging==20.9
 testtools==2.5.0
 coverage==5.5


### PR DESCRIPTION
Pytest has some improvements over nose, and the original nose is abandoned. Also vs code has support for unittest and pytest and not nose.

- [x] autopep8
- [x] integration 20.04
- no changelog entry needed for this change