### PR TITLE
Update cryptography (pypi) and certifi (reference source)

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  - dependabot: update golang.org/x/net from 0.14.0 to 0.17.0 in /inbm/trtl (addresses CVE-2023-39325, CVE-2023-44487)
  - update pypi urllib3 from 1.26.17 to 1.26.18 (addresses CVE-2023-45803 in urllib3)
  - depandabot: bump github.com/docker/docker from 24.0.5+incompatible to 24.0.7+incompatible in /inbm/trtl (addresses GHSA-jq35-85cj-fj4p)
+ - update cryptography dependency in dispatcher-agent from 41.0.4 to 41.0.5, addressing CVE-2023-5678
+ - update included reference certifi source code from 2020.12.05 to 2023.7.22, which was not a security issue per se but was flagged in BDBA as it contains CVE-2022-23491 and CVE-2023-37920
 
 ## 4.1.4 - 2023-10-11
 

--- a/inbm/dispatcher-agent/requirements.txt
+++ b/inbm/dispatcher-agent/requirements.txt
@@ -1,7 +1,7 @@
 #Production
 
 psutil==5.9.5
-cryptography==41.0.4
+cryptography==41.0.5
 jsonschema==4.1.2
 shortuuid==1.0.1
 requests==2.31.0

--- a/inbm/dockerfiles/image.main.m4
+++ b/inbm/dockerfiles/image.main.m4
@@ -215,7 +215,7 @@ RUN cp -v docker-sample-container/docker/certs/succeed_rpm_key.pem /output
 
 FROM base as fpm
 WORKDIR /
-RUN wget https://github.com/certifi/python-certifi/archive/refs/tags/2020.12.05.zip -O python-certifi-src-2020.12.05.zip
+RUN wget https://github.com/certifi/python-certifi/archive/refs/tags/2023.07.22.zip -O python-certifi-src-2023.07.22.zip
 COPY inbm/fpm /src/fpm
 WORKDIR /src/fpm
 COPY --from=inb-provision-certs /output/inb-provision-certs /src/fpm/mqtt/template/usr/bin/inb-provision-certs
@@ -224,7 +224,7 @@ COPY --from=inb-provision-ota-cert /output/inb-provision-ota-cert /src/fpm/mqtt/
 RUN mkdir -p /src/fpm/mqtt/template/usr/share/intel-manageability
 COPY third-party-programs.txt /src/fpm/mqtt/template/usr/share/intel-manageability/third-party-programs.txt
 COPY inbm/version.txt /src/version.txt
-RUN mv /python-certifi-src-2020.12.05.zip /src/fpm/mqtt/template/usr/share/intel-manageability && \
+RUN mv /python-certifi-src-2023.07.22.zip /src/fpm/mqtt/template/usr/share/intel-manageability && \
     echo "The certifi source code is governed by the terms of the Mozilla Public License 2.0." >/src/fpm/mqtt/template/usr/share/intel-manageability/python-certifi-src-NOTICE.txt
 RUN perl -pi -e 'chomp if eof' /src/version.txt
 RUN rm -rf output/ && \


### PR DESCRIPTION
This addresses some CVEs flagged by BDBA.

- [x] check BDBA scan clears addressed issues
- [x] integration reloaded slow
- [x] changelog
- autopep8 not needed