### PR TITLE
Enhance SOTA update process with conditional reboot and default parameter values

### DIFF
--- a/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
+++ b/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
@@ -210,7 +210,7 @@ class Dispatcher:
                         create_snapshotter('update',
                                            snap_num='1',
                                            proceed_without_rollback=True,
-                                           ).commit()
+                                           reboot_device=True).commit()
                 except OSError:
                     # harmless here--mender commit is speculative
                     pass

--- a/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
@@ -36,7 +36,7 @@ class SotaOsFactory:
     """
 
     def __init__(self,  dispatcher_broker: DispatcherBroker,
-                 sota_repos: Optional[str], package_list: list[str]) -> None:
+                 sota_repos: Optional[str] = None, package_list: list[str] = []) -> None:
         """Initializes OsFactory.
 
         @param dispatcher_broker: DispatcherBroker object used to communicate with other INBM services
@@ -57,7 +57,7 @@ class SotaOsFactory:
             raise ValueError('Unsupported OS type.')
 
     def get_os(self, os_type) -> "ISotaOs":
-        """Gets the concrete Os-based class for the current operating system
+        """Gets the concrete OS-based class for the current operating system
 
         @return concrete class for the operating system
         """

--- a/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
@@ -99,13 +99,15 @@ class ISotaOs(ABC):
         pass
 
     @abstractmethod
-    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str], proceed_without_rollback: bool) -> Snapshot:
+    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str],
+                           proceed_without_rollback: bool, reboot_device: bool) -> Snapshot:
         """Create a snapshotter object
 
         @param sota_cmd: Command to create a snapshot
         @param snap_num: Snapshot number
         @param proceed_without_rollback: True to not rollback the system in event of an error;
         False to rollback.
+        @param reboot_device: If True, reboot device on success or failure, otherwise, do not reboot.
         """
         pass
 
@@ -137,10 +139,12 @@ class YoctoX86_64(ISotaOs):
         logger.debug("")
         return YoctoX86_64Updater()
 
-    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str], proceed_without_rollback: bool) -> Snapshot:
+    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str],
+                           proceed_without_rollback: bool, reboot_device: bool) -> Snapshot:
         logger.debug("")
         trtl = Trtl(PseudoShellRunner(), BTRFS)
-        return YoctoSnapshot(trtl, sota_cmd, self._dispatcher_broker, snap_num, proceed_without_rollback)
+        return YoctoSnapshot(trtl, sota_cmd, self._dispatcher_broker, snap_num,
+                             proceed_without_rollback, reboot_device)
 
     def create_downloader(self) -> Downloader:
         logger.debug("")
@@ -165,10 +169,12 @@ class YoctoARM(ISotaOs):
         logger.debug("")
         return YoctoARMUpdater()
 
-    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str], proceed_without_rollback: bool) -> Snapshot:
+    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str],
+                           proceed_without_rollback: bool, reboot_device: bool) -> Snapshot:
         logger.debug("")
         trtl = Trtl(PseudoShellRunner(), BTRFS)
-        return YoctoSnapshot(trtl, sota_cmd, self._dispatcher_broker, snap_num, proceed_without_rollback)
+        return YoctoSnapshot(trtl, sota_cmd, self._dispatcher_broker,
+                             snap_num, proceed_without_rollback, reboot_device)
 
     def create_downloader(self) -> Downloader:
         logger.debug("")
@@ -203,10 +209,12 @@ class DebianBasedSotaOs(ISotaOs):
         logger.debug("")
         return DebianBasedUpdater(self._package_list)
 
-    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str], proceed_without_rollback: bool) -> Snapshot:
+    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str],
+                           proceed_without_rollback: bool, reboot_device: bool) -> Snapshot:
         logger.debug("")
         trtl = Trtl(PseudoShellRunner(), BTRFS)
-        return DebianBasedSnapshot(trtl, sota_cmd, self._dispatcher_broker, snap_num, proceed_without_rollback)
+        return DebianBasedSnapshot(trtl, sota_cmd, self._dispatcher_broker,
+                                   snap_num, proceed_without_rollback, reboot_device)
 
     def create_downloader(self) -> Downloader:
         return DebianBasedDownloader()
@@ -232,10 +240,12 @@ class Windows(ISotaOs):
         logger.debug("")
         return WindowsUpdater()
 
-    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str], proceed_without_rollback: bool) -> Snapshot:
+    def create_snapshotter(self, sota_cmd: str, snap_num: Optional[str],
+                           proceed_without_rollback: bool, reboot_device: bool) -> Snapshot:
         logger.debug("")
         trtl = Trtl(PseudoShellRunner())
-        return WindowsSnapshot(trtl, sota_cmd, snap_num, proceed_without_rollback)
+        return WindowsSnapshot(trtl, sota_cmd, snap_num,
+                               proceed_without_rollback, reboot_device)
 
     def create_downloader(self) -> Downloader:
         return WindowsDownloader()

--- a/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
@@ -38,14 +38,16 @@ class Snapshot(metaclass=ABCMeta):  # pragma: no cover
     @param sota_cmd: SOTA command (update)
     @param snap_num: snapshot number
     @param proceed_without_rollback: Rollback on failure if False; otherwise, rollback.
+    @param reboot_device: If True, reboot device on success or failure, otherwise, do not reboot.
     """
 
     def __init__(self, trtl: Trtl, sota_cmd: str,  snap_num: Optional[str],
-                 proceed_without_rollback: bool) -> None:
+                 proceed_without_rollback: bool, reboot_device: bool) -> None:
         self.trtl = trtl
         self.sota_cmd = sota_cmd
         self.snap_num = snap_num
         self.proceed_without_rollback = proceed_without_rollback
+        self._reboot_device = reboot_device
 
     @abstractmethod
     def take_snapshot(self) -> None:
@@ -103,12 +105,14 @@ class DebianBasedSnapshot(Snapshot):
         @param dispatcher_broker: DispatcherBroker object used to communicate with other INBM services
         @param snap_num: snapshot number
         @param proceed_without_rollback: Rollback on failure if False; otherwise, rollback.
+        @param reboot_device: If True, reboot device on success or failure, otherwise, do not reboot.
         """
 
     def __init__(self, trtl: Trtl, sota_cmd: str,
-                 dispatcher_broker: DispatcherBroker, snap_num: Optional[str], proceed_without_rollback: bool) -> None:
+                 dispatcher_broker: DispatcherBroker, snap_num: Optional[str],
+                 proceed_without_rollback: bool, reboot_device: bool) -> None:
         super().__init__(trtl, sota_cmd,
-                         snap_num, proceed_without_rollback)
+                         snap_num, proceed_without_rollback, reboot_device)
         self._dispatcher_broker = dispatcher_broker
 
     def take_snapshot(self) -> None:
@@ -227,8 +231,9 @@ class DebianBasedSnapshot(Snapshot):
             rebooter.reboot()
         else:
             time.sleep(time_to_wait_before_reboot)
-        #logger.debug("Rebooting to recover from failed SOTA...")
-        #rebooter.reboot()
+            if self._reboot_device:
+                logger.debug("Rebooting to recover from failed SOTA...")
+                rebooter.reboot()
 
     def revert(self, rebooter: Rebooter, time_to_wait_before_reboot: int) -> None:
         """Revert after second system SOTA boot when we see a problem with startup.
@@ -262,12 +267,13 @@ class WindowsSnapshot(Snapshot):  # pragma: no cover
         @param sota_cmd: SOTA command (update)
         @param snap_num: snapshot number
         @param proceed_without_rollback: Rollback on failure if False; otherwise, rollback.
+        @param reboot_device: If True, reboot device on success or failure, otherwise, do not reboot.
         """
 
     def __init__(self, trtl: Trtl, sota_cmd: str,  snap_num: Optional[str],
-                 proceed_without_rollback: bool) -> None:
+                 proceed_without_rollback: bool, reboot_device: bool) -> None:
         super().__init__(trtl, sota_cmd,
-                         snap_num, proceed_without_rollback)
+                         snap_num, proceed_without_rollback, reboot_device)
 
     def take_snapshot(self) -> None:
         """Takes a Snapshot through Trtl before running commands. if Snapshot fails,
@@ -329,9 +335,10 @@ class YoctoSnapshot(Snapshot):
    """
 
     def __init__(self, trtl: Trtl, sota_cmd: str,
-                 dispatcher_broker: DispatcherBroker, snap_num: Optional[str], proceed_without_rollback: bool) -> None:
+                 dispatcher_broker: DispatcherBroker, snap_num: Optional[str],
+                 proceed_without_rollback: bool, reboot_device: bool) -> None:
         super().__init__(trtl, sota_cmd,
-                         snap_num, proceed_without_rollback)
+                         snap_num, proceed_without_rollback, reboot_device)
         self._dispatcher_broker = dispatcher_broker
 
     def take_snapshot(self) -> None:

--- a/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
@@ -223,16 +223,15 @@ class DebianBasedSnapshot(Snapshot):
         @param rebooter: Object implementing reboot() method
         @param time_to_wait_before_reboot: If we are rebooting, wait this many seconds first.
         """
-        logger.debug("time_to_wait_before_reboot = " + str(time_to_wait_before_reboot))
         dispatcher_state.clear_dispatcher_state()
         if self.snap_num:
             self._rollback_and_delete_snap()
             logger.debug("Rebooting to recover from failed SOTA...")
             rebooter.reboot()
-        else:
-            time.sleep(time_to_wait_before_reboot)
+        else:            
             if self._reboot_device:
-                logger.debug("Rebooting to recover from failed SOTA...")
+                logger.debug(f"Rebooting to recover from failed SOTA...time_to_wait_before_reboot = {str(time_to_wait_before_reboot)}")
+                time.sleep(time_to_wait_before_reboot)
                 rebooter.reboot()
 
     def revert(self, rebooter: Rebooter, time_to_wait_before_reboot: int) -> None:

--- a/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
@@ -223,10 +223,12 @@ class DebianBasedSnapshot(Snapshot):
         dispatcher_state.clear_dispatcher_state()
         if self.snap_num:
             self._rollback_and_delete_snap()
+            logger.debug("Rebooting to recover from failed SOTA...")
+            rebooter.reboot()
         else:
             time.sleep(time_to_wait_before_reboot)
-        logger.debug("Rebooting to recover from failed SOTA...")
-        rebooter.reboot()
+        #logger.debug("Rebooting to recover from failed SOTA...")
+        #rebooter.reboot()
 
     def revert(self, rebooter: Rebooter, time_to_wait_before_reboot: int) -> None:
         """Revert after second system SOTA boot when we see a problem with startup.

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -356,7 +356,7 @@ class SOTA:
                     self._update_logger.status = OTA_PENDING
                     self._update_logger.error = ""
                 self._update_logger.save_log()
-                if self.sota_mode == 'download-only' or not self._is_reboot_device():
+                if (self.sota_mode == 'download-only') or (not self._is_reboot_device()):
                     self._dispatcher_broker.telemetry("No reboot (SOTA pass)")
                 else:
                     self._dispatcher_broker.telemetry("Going to reboot (SOTA pass)")
@@ -373,7 +373,7 @@ class SOTA:
                 raise SotaError(SOTA_FAILURE)
 
     def _is_reboot_device(self) -> bool:
-        return False if self._reboot_device in ["No", "N", "n", "no", "NO"] else True
+        return self._reboot_device not in ["No", "N", "n", "no", "NO"]
     
     def check(self) -> None:
         """Perform manifest checking before SOTA"""

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -125,7 +125,7 @@ class SOTA:
             # If an exception occurs during string conversion, raise that exception
             raise SotaError('package_list is not a string in manifest') from e
 
-        self._device_reboot = parsed_manifest['deviceReboot']
+        self._reboot_device = parsed_manifest['deviceReboot']        
         self._install_check_service = install_check_service
 
         if self._repo_type == LOCAL_SOURCE:
@@ -239,7 +239,7 @@ class SOTA:
         if self.sota_cmd == 'rollback':
             self.snap_num = setup_helper.get_snapper_snapshot_number()
         snapshot = self.factory.create_snapshotter(
-            self.sota_cmd, self.snap_num, self.proceed_without_rollback)
+            self.sota_cmd, self.snap_num, self.proceed_without_rollback, self._is_reboot_device())
         rebooter = self.factory.create_rebooter()
 
         if self.sota_state == 'diagnostic_system_unhealthy':
@@ -356,7 +356,7 @@ class SOTA:
                     self._update_logger.status = OTA_PENDING
                     self._update_logger.error = ""
                 self._update_logger.save_log()
-                if self.sota_mode == 'download-only' or self._device_reboot in ["No", "N", "n", "no", "NO"]:  # pragma: no cover
+                if self.sota_mode == 'download-only' or not self._is_reboot_device():
                     self._dispatcher_broker.telemetry("No reboot (SOTA pass)")
                 else:
                     self._dispatcher_broker.telemetry("Going to reboot (SOTA pass)")
@@ -372,6 +372,9 @@ class SOTA:
                 self._dispatcher_broker.send_result(SOTA_FAILURE)
                 raise SotaError(SOTA_FAILURE)
 
+    def _is_reboot_device(self) -> bool:
+        return False if self._reboot_device in ["No", "N", "n", "no", "NO"] else True
+    
     def check(self) -> None:
         """Perform manifest checking before SOTA"""
         logger.debug("")

--- a/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
@@ -26,57 +26,58 @@ class TestOsFactory(TestCase):
                     []).get_os('YoctoX86_64')) is YoctoX86_64
 
     def test_get_factory_windows(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows')) is Windows
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('Windows')) is Windows
 
     def test_raise_error_unsupported_OsFactory(self) -> None:
-        factory = SotaOsFactory(self.mock_disp_broker, None, [])
-        self.assertRaises(ValueError, factory.get_os, "MacOS")
+        factory = SotaOsFactory(self.mock_disp_broker)
+        with self.assertRaises(ValueError):
+                factory.get_os("MacOS")
 
     def test_create_ubuntu_snapshot_checker(self) -> None:
-        ubuntu_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu')
+        ubuntu_os = SotaOsFactory(self.mock_disp_broker).get_os('Ubuntu')
         snapshotter = ubuntu_os.create_snapshotter('update', '1', False, True)
         self.assertIsInstance(snapshotter, DebianBasedSnapshot)
 
     def test_create_yocto_snapshot_checker(self) -> None:
-        yocto_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64')
+        yocto_os = SotaOsFactory(self.mock_disp_broker).get_os('YoctoX86_64')
         snapshotter = yocto_os.create_snapshotter('update', '1', False, True)
         self.assertIsInstance(snapshotter, YoctoSnapshot)
 
     def test_create_windows_snapshot_checker(self) -> None:
-        windows_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows')
+        windows_os = SotaOsFactory(self.mock_disp_broker).get_os('Windows')
         snapshotter = windows_os.create_snapshotter('update', '1', False, True)
         self.assertIsInstance(snapshotter, WindowsSnapshot)
 
     def test_create_ubuntu_updater_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_os_updater()) \
-            is DebianBasedUpdater
+        updater = SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_os_updater()
+        self.assertIsInstance(updater, DebianBasedUpdater)
 
     def test_create_yocto_updater_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64').create_os_updater()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('YoctoX86_64').create_os_updater()) \
             is YoctoX86_64Updater
 
     def test_create_ubuntu_setup_helper_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_setup_helper()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('Ubuntu').create_setup_helper()) \
             is DebianBasedSetupHelper
 
     def test_create_yocto_setup_helper_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64').create_setup_helper()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('YoctoX86_64').create_setup_helper()) \
             is YoctoSetupHelper
 
     def test_create_windows_setup_helper_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows').create_setup_helper()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('Windows').create_setup_helper()) \
             is WindowsSetupHelper
 
     def test_create_ubuntu_downloader(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_downloader()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('Ubuntu').create_downloader()) \
             is DebianBasedDownloader
 
     def test_create_yocto_downloader(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64').create_downloader()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('YoctoX86_64').create_downloader()) \
             is YoctoDownloader
 
     def test_create_windows_downloader(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows').create_downloader()) \
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('Windows').create_downloader()) \
             is WindowsDownloader
 
     @patch('platform.system')

--- a/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
@@ -33,16 +33,19 @@ class TestOsFactory(TestCase):
         self.assertRaises(ValueError, factory.get_os, "MacOS")
 
     def test_create_ubuntu_snapshot_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_snapshotter('update', '1', False)) \
-            is DebianBasedSnapshot
+        ubuntu_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu')
+        snapshotter = ubuntu_os.create_snapshotter('update', '1', False, True)
+        self.assertIsInstance(snapshotter, DebianBasedSnapshot)
 
     def test_create_yocto_snapshot_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64').create_snapshotter('update', '1', False)) \
-            is YoctoSnapshot
+        yocto_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('YoctoX86_64')
+        snapshotter = yocto_os.create_snapshotter('update', '1', False, True)
+        self.assertIsInstance(snapshotter, YoctoSnapshot)
 
     def test_create_windows_snapshot_checker(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows').create_snapshotter('update', '1', False)) \
-            is WindowsSnapshot
+        windows_os = SotaOsFactory(self.mock_disp_broker, None, []).get_os('Windows')
+        snapshotter = windows_os.create_snapshotter('update', '1', False, True)
+        self.assertIsInstance(snapshotter, WindowsSnapshot)
 
     def test_create_ubuntu_updater_checker(self) -> None:
         assert type(SotaOsFactory(self.mock_disp_broker, None, []).get_os('Ubuntu').create_os_updater()) \

--- a/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
@@ -68,7 +68,7 @@ class TestSnapshot(unittest.TestCase):
     def test_Ubuntu_snapshot_raises2(self, rc, err, mock_trtl_single_snapshot) -> None:
         with patch('builtins.open', new_callable=mock_open()) as m:
             factory = SotaOsFactory(
-                MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('Ubuntu')
+                MockDispatcherBroker.build_mock_dispatcher_broker()).get_os('Ubuntu')
             snapshot = factory.create_snapshotter("update", '1', False, True)
             mock_trtl_single_snapshot.return_value = (rc, err)
             try:

--- a/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
@@ -24,7 +24,7 @@ class TestSnapshot(unittest.TestCase):
     def test_ubuntu_delete_snap(self, order, rc, err, mock_del_snap) -> None:
         factory = SotaOsFactory(
             MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('Ubuntu')
-        snapshot = factory.create_snapshotter("update", '1', False)
+        snapshot = factory.create_snapshotter("update", '1', False, True)
         mock_del_snap.return_value = (rc, err)
         val = snapshot.commit()
         mock_del_snap.assert_called_once()
@@ -40,7 +40,7 @@ class TestSnapshot(unittest.TestCase):
     def test_ubuntu_snapshot(self, order, rc, err, mock_trtl_single_snapshot, mock_state) -> None:
         factory = SotaOsFactory(
             MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('Ubuntu')
-        snapshot = factory.create_snapshotter("update", '1', False)
+        snapshot = factory.create_snapshotter("update", '1', False, True)
         with patch('builtins.open', new_callable=mock_open()) as m:
             if order == 1:
                 mock_trtl_single_snapshot.return_value = (rc, err)
@@ -55,7 +55,7 @@ class TestSnapshot(unittest.TestCase):
     def test_Ubuntu_snapshot_raises1(self, rc, err, mock_pickle_dump, mock_trtl_single_snapshot) -> None:
         factory = SotaOsFactory(
             MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('Ubuntu')
-        snapshot = factory.create_snapshotter("update", '1', False)
+        snapshot = factory.create_snapshotter("update", '1', False, True)
         with patch('builtins.open', new_callable=mock_open()) as m:
             mock_trtl_single_snapshot.return_value = (rc, err)
             with self.assertRaises(SotaError):
@@ -69,7 +69,7 @@ class TestSnapshot(unittest.TestCase):
         with patch('builtins.open', new_callable=mock_open()) as m:
             factory = SotaOsFactory(
                 MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('Ubuntu')
-            snapshot = factory.create_snapshotter("update", '1', False)
+            snapshot = factory.create_snapshotter("update", '1', False, True)
             mock_trtl_single_snapshot.return_value = (rc, err)
             try:
                 snapshot.take_snapshot()
@@ -86,7 +86,7 @@ class TestUbuntuSnapshot(unittest.TestCase):
         trtl = Mock()
         trtl.single_snapshot.return_value = "1", "Error!"
 
-        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "1", True)
+        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "1", True, True)
         ubuntu_snapshot.take_snapshot()
         assert dispatcher_broker.telemetry.call_count > 0
 
@@ -101,7 +101,7 @@ class TestUbuntuSnapshot(unittest.TestCase):
         trtl = Mock()
         trtl.single_snapshot.return_value = "1", None
 
-        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "1", True)
+        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "1", True, True)
         ubuntu_snapshot.take_snapshot()
 
         assert dispatcher_broker.telemetry.call_count > 0
@@ -113,7 +113,7 @@ class TestUbuntuSnapshot(unittest.TestCase):
         dispatcher_broker = Mock()
         trtl = Mock()
 
-        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "", True)
+        ubuntu_snapshot = DebianBasedSnapshot(trtl, "command", dispatcher_broker, "", True, True)
         ubuntu_snapshot._rollback_and_delete_snap()
 
         assert dispatcher_broker.telemetry.call_count > 0
@@ -124,7 +124,7 @@ class TestUbuntuSnapshot(unittest.TestCase):
     @patch('dispatcher.sota.snapshot.dispatcher_state', autospec=True)
     def test_revert_succeeds(self, mock_dispatcher_state) -> None:
         rebooter = Mock()
-        ubuntu_snapshot = DebianBasedSnapshot(Mock(), "command", Mock(), "", True)
+        ubuntu_snapshot = DebianBasedSnapshot(Mock(), "command", Mock(), "", True, True)
         ubuntu_snapshot._rollback_and_delete_snap = Mock()  # type: ignore[method-assign]
         ubuntu_snapshot.snap_num = "1"
         ubuntu_snapshot.revert(rebooter, 0)
@@ -143,7 +143,7 @@ class TestYoctoSnapshot(unittest.TestCase):
         dispatcher_callbacks = Mock()
         dispatcher_broker = Mock()
 
-        yocto_snapshot = YoctoSnapshot(Mock(), "command", dispatcher_broker, "1", True)
+        yocto_snapshot = YoctoSnapshot(Mock(), "command", dispatcher_broker, "1", True, True)
         yocto_snapshot.take_snapshot()
 
         assert dispatcher_broker.telemetry.call_count > 0
@@ -160,7 +160,7 @@ class TestYoctoSnapshot(unittest.TestCase):
         dispatcher_callbacks = Mock()
         dispatcher_broker = Mock()
 
-        yocto_snapshot = YoctoSnapshot(Mock(), "command", Mock(), "1", True)
+        yocto_snapshot = YoctoSnapshot(Mock(), "command", Mock(), "1", True, True)
         yocto_snapshot.take_snapshot()
         mock_consume_disp_file.assert_called_once()
         mock_write_state_file.assert_called_once()
@@ -174,7 +174,7 @@ class TestYoctoSnapshot(unittest.TestCase):
         dispatcher_callbacks = Mock()
         dispatcher_broker = Mock()
 
-        yocto_snapshot = YoctoSnapshot(Mock(), "command", Mock(), "1", True)
+        yocto_snapshot = YoctoSnapshot(Mock(), "command", Mock(), "1", True, True)
         yocto_snapshot.take_snapshot()
         mock_consume_disp_file.assert_not_called()
         mock_write_state_file.assert_called_once()
@@ -188,7 +188,7 @@ class TestYoctoSnapshot(unittest.TestCase):
         dispatcher_callbacks = Mock()
         dispatcher_broker = Mock()
 
-        yocto_snapshot = YoctoSnapshot(Mock(), "command", dispatcher_broker, "1", True)
+        yocto_snapshot = YoctoSnapshot(Mock(), "command", dispatcher_broker, "1", True, True)
         failed = False
         try:
             yocto_snapshot.take_snapshot()


### PR DESCRIPTION
>### Start of GenAI Co-Pilot generated PR Summary

## Types of major changes in the pull request
bug_fix, enhancement


___

## Pull request change summary
This PR introduces enhancements and bug fixes related to the reboot behavior of the SOTA (Software Over-The-Air) update process:
- The create_snapshotter method across various OS classes now includes a reboot_device parameter to control whether the device should reboot after a snapshot operation.
- The SotaOsFactory constructor now has default values for sota_repos and package_list, enhancing the robustness of object creation.
- The Snapshot class and its subclasses have been updated to accept the reboot_device parameter, which is used to determine if a reboot should occur after a snapshot operation.
- The recover method in DebianBasedSnapshot now conditionally triggers a reboot based on the reboot_device flag.
- The Sota class now uses the _reboot_device attribute instead of _device_reboot to align with the changes made in snapshot-related classes.
- Unit tests have been updated to reflect the changes in the SotaOsFactory, Snapshot, and related classes.


___

## Details of Pull Request changes by File
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>dispatcher_class.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/dispatcher_class.py<br><br>

**Add reboot_device=True parameter to create_snapshotter <br>method call within _perform_startup_tasks.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-ef384698d3e44108d77ef097d0e235360755ea8c84bd4eca877b7ebff5a54480"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>os_factory.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/sota/os_factory.py<br><br>

**- Add default values for sota_repos and package_list in <br>SotaOsFactory constructor.
- Update docstring for get_os <br>method.
- Add reboot_device parameter to create_snapshotter <br>method in OS classes.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-82f11b61db84331aa7664e2e03ed98fe5a612762d49db67dde22033f79ef3652"> +21/-11</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>snapshot.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/sota/snapshot.py<br><br>

**- Add reboot_device parameter to Snapshot class constructor <br>and its subclasses.
- Modify recover method to conditionally <br>reboot based on reboot_device flag.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-6ff8efed1fa143c1a29e89fe6f5af960471101a2710633823325f52ea80eeba3"> +20/-12</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sota.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/sota/sota.py<br><br>

**- Replace _device_reboot with _reboot_device to align with <br>other changes.
- Add _is_reboot_device method to check if <br>the device should reboot.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-5ac42888120109a4e68ad60db290e4fb7cf049833d66c3caff615b8922c68eef"> +6/-3</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_os_factory.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py<br><br>

**- Update tests to reflect changes in SotaOsFactory and <br>related classes.
- Remove unnecessary parameters in test <br>method calls.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-59cad237dd2157e6443b7efbf0987a75bb25dcb32bebd32f64ebc1be4e1304f6"> +22/-18</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_snapshot.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py<br><br>

**- Update tests to pass reboot_device parameter to <br>create_snapshotter method.
- Adjust assertions and mock <br>setups to accommodate the new parameter.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/475/files#diff-baba8c5da29db151abc64593b62c79fb4d75e84ebeed52e81dcef568aa5e7157"> +13/-13</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of Co-Pilot generated PR Summary