### PR TITLE
(538549) Improve errors when unable to fetch from URLs

### DIFF
--- a/inbm-lib/inbm_lib/detect_os.py
+++ b/inbm-lib/inbm_lib/detect_os.py
@@ -8,7 +8,7 @@ from enum import Enum
 from os import path
 import os
 import platform
-from subprocess import SubprocessError # nosec
+from subprocess import SubprocessError  # nosec
 from typing import Optional
 
 from .constants import MENDER_FILE_PATH, SYSTEM_IS_YOCTO_PATH, FORCE_YOCTO_PATH, CENTOS_VERSION_PATH

--- a/inbm-lib/inbm_lib/trtl.py
+++ b/inbm-lib/inbm_lib/trtl.py
@@ -15,7 +15,7 @@ from typing import Optional, Tuple
 import logging
 
 from .constants import DOCKER, COMPOSE, TRTL_PATH
-from subprocess import Popen, PIPE # nosec: B405, B404
+from subprocess import Popen, PIPE  # nosec: B405, B404
 import shlex
 import time
 

--- a/inbm-lib/inbm_lib/xmlhandler.py
+++ b/inbm-lib/inbm_lib/xmlhandler.py
@@ -12,7 +12,7 @@ import logging
 # following line is only used for type checking; we used defusedxml for
 # actual processing
 # As of Feb 2024, we still have to use xml.etree.  There is no equivalent in defusedxml
-from xml.etree.ElementTree import Element, SubElement # nosec: S405, B405
+from xml.etree.ElementTree import Element, SubElement  # nosec: S405, B405
 from defusedxml.ElementTree import XMLParser, parse, ParseError, tostring
 from inbm_common_lib.utility import get_canonical_representation_of_path
 from .security_masker import mask_security_info
@@ -184,8 +184,9 @@ class XmlHandler:
         logger.debug("XML add element")
         element = self._root.find(xpath)
         if element is None:
-            raise XmlException(f"cannot add attribute '{element_name}' to XML path '{xpath}'.  Unable to find path in XML document.")
-        
+            raise XmlException(
+                f"cannot add attribute '{element_name}' to XML path '{xpath}'.  Unable to find path in XML document.")
+
         try:
             sub_element = Element(element_name)
             sub_element.text = element_value

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
  - RTC 538468 - paho-mqtt upgrade broke cloudadapter's mqtt connections. Fixed proxy setting code to not override all sockets with proxy as paho-mqtt 1.6.0 relies on listening/connecting to localhost to set up sockets, and this doesn't work with a global proxy on all sockets.
+ - RTC 538549 - improved errors when unable to fetch from URLs. For example, if INBM receives a "404 Not Found" it will return this as part of its error instead of simply returning a generic error message about being unable to fetch the URL.
 
 ### Security
  - RTC 537811 - Bump cryptography from 41.0.6 to 42.0.2 in /inbm/dispatcher-agent (addresses CVE-2023-5678, CVE-2023-6129)

--- a/inbm/configuration-agent/configuration/tests/unit/test_xml_key_value_store.py
+++ b/inbm/configuration-agent/configuration/tests/unit/test_xml_key_value_store.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import mock_open
 # This is a test file.  It shouldn't be included in bandit tests, but is with the default configuration
 # used to test.
-from xml.etree.ElementTree import ElementTree # nosec: B405
+from xml.etree.ElementTree import ElementTree  # nosec: B405
 
 from configuration.xml_key_value_store import XmlException, XmlKeyValueStore
 from configuration.configuration_exception import ConfigurationException

--- a/inbm/diagnostic-agent/diagnostic/event_watcher.py
+++ b/inbm/diagnostic-agent/diagnostic/event_watcher.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from subprocess import Popen # nosec: B404
+from subprocess import Popen  # nosec: B404
 from threading import Thread, Lock
 from typing import Any, Optional, List
 

--- a/inbm/dispatcher-agent/dispatcher/aota/aota_command.py
+++ b/inbm/dispatcher-agent/dispatcher/aota/aota_command.py
@@ -283,7 +283,7 @@ class Docker(AotaCommand):
             f'Package: {self._uri} Fetch Result: {result}')
 
         if result.status != CODE_OK:
-            raise AotaError(result.message)
+            raise AotaError(f"Unable to download docker image. Status = {result.status}, message = {result.message}.")
 
         container = TrtlContainer(
             self._trtl,
@@ -379,8 +379,10 @@ class DockerCompose(AotaCommand):
                          password=self._password)
         self._dispatcher_broker.telemetry(
             f'Package: {self._uri} Fetch Result: {get_result}')
+        
         if get_result.status != CODE_OK:
-            raise AotaError("Unable to download docker-compose container.")
+            raise AotaError(f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
+        
         (result, message, code) = self._trtl.up(self._container_tag, self._dockerComposeFile)
         if code != 0:
             raise AotaError(message)
@@ -452,7 +454,7 @@ class DockerCompose(AotaCommand):
             f'Package: {self._uri} Fetch Result: {get_result}')
 
         if get_result.status != CODE_OK:
-            raise AotaError('Unable to download docker-compose container.')
+            raise AotaError(f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
 
     def list(self):
         """This method list the containers

--- a/inbm/dispatcher-agent/dispatcher/aota/aota_command.py
+++ b/inbm/dispatcher-agent/dispatcher/aota/aota_command.py
@@ -283,7 +283,8 @@ class Docker(AotaCommand):
             f'Package: {self._uri} Fetch Result: {result}')
 
         if result.status != CODE_OK:
-            raise AotaError(f"Unable to download docker image. Status = {result.status}, message = {result.message}.")
+            raise AotaError(
+                f"Unable to download docker image. Status = {result.status}, message = {result.message}.")
 
         container = TrtlContainer(
             self._trtl,
@@ -379,10 +380,11 @@ class DockerCompose(AotaCommand):
                          password=self._password)
         self._dispatcher_broker.telemetry(
             f'Package: {self._uri} Fetch Result: {get_result}')
-        
+
         if get_result.status != CODE_OK:
-            raise AotaError(f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
-        
+            raise AotaError(
+                f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
+
         (result, message, code) = self._trtl.up(self._container_tag, self._dockerComposeFile)
         if code != 0:
             raise AotaError(message)
@@ -454,7 +456,8 @@ class DockerCompose(AotaCommand):
             f'Package: {self._uri} Fetch Result: {get_result}')
 
         if get_result.status != CODE_OK:
-            raise AotaError(f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
+            raise AotaError(
+                f"Unable to download docker-compose container. Status = {get_result.status}, message = {get_result.message}.")
 
     def list(self):
         """This method list the containers

--- a/inbm/dispatcher-agent/dispatcher/aota/application_command.py
+++ b/inbm/dispatcher-agent/dispatcher/aota/application_command.py
@@ -121,7 +121,8 @@ class Application(AotaCommand):
             f'Package: {self._uri} Fetch Result: {get_result}')
 
         if get_result.status != CODE_OK:
-            raise AotaError("Unable to download application package.")
+            raise AotaError(f"Unable to download application package. Status = {get_result.status}, message = {get_result.message}.")
+        
         return application_repo
 
     def _reboot(self, cmd: str) -> None:

--- a/inbm/dispatcher-agent/dispatcher/aota/application_command.py
+++ b/inbm/dispatcher-agent/dispatcher/aota/application_command.py
@@ -121,8 +121,9 @@ class Application(AotaCommand):
             f'Package: {self._uri} Fetch Result: {get_result}')
 
         if get_result.status != CODE_OK:
-            raise AotaError(f"Unable to download application package. Status = {get_result.status}, message = {get_result.message}.")
-        
+            raise AotaError(
+                f"Unable to download application package. Status = {get_result.status}, message = {get_result.message}.")
+
         return application_repo
 
     def _reboot(self, cmd: str) -> None:

--- a/inbm/dispatcher-agent/dispatcher/packagemanager/package_manager.py
+++ b/inbm/dispatcher-agent/dispatcher/packagemanager/package_manager.py
@@ -8,6 +8,7 @@
 """
 
 import hashlib
+import http.client
 import json
 import logging
 import os
@@ -395,9 +396,12 @@ def get(url: CanonicalUri,
             repo.add_from_requests_response(
                 urlparse(url.value).path.split('/')[-1], response, umask=umask)
     except HTTPError as e:
-        if e.response:
+        if e.response is not None:
             status_code = e.response.status_code
-            reason = e.response.reason
+            if not response.reason:
+                reason = http.client.responses.get(e.response.status_code, "Unknown Status Code")
+            else:
+                reason = e.response.reason
         else:
             status_code = 0
             reason = "(no response--unable to look up reason)"

--- a/inbm/dispatcher-agent/dispatcher/source/linux_gpg_key.py
+++ b/inbm/dispatcher-agent/dispatcher/source/linux_gpg_key.py
@@ -3,7 +3,7 @@
     SPDX-License-Identifier: Apache-2.0
 """
 import logging
-import subprocess # nosec B404
+import subprocess  # nosec B404
 import os
 import requests
 


### PR DESCRIPTION
<h1>Suggested PR Title - Improve Error Messaging for Failed URL Fetches in INBM</h1>
RTC 538549 - improved errors when unable to fetch from URLs. For example, if INBM receives a "404 Not Found" it will return this as part of its error instead of simply returning a generic error message about being unable to fetch the URL.

- [x] format-python.sh
- [x] integration test
- [x] Changelog
- [x] manual test with aota package download
- [x] security checklist reviewed

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>
### Release Version: v3.7.1


>### Start of GenAI Co-Pilot generated PR Summary

## Types of major changes in the pull request
enhancement, bug_fix


___

## Pull request change summary
- Enhanced error messages in aota_command.py and application_command.py to include HTTP status codes and messages when downloads fail.
- Fixed a bug in package_manager.py where a None response would not properly fall back to a default error message.
- Updated the Changelog to document the improvements in error handling for fetching URLs.


___

## Details of Pull Request changes by File
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>aota_command.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/aota/aota_command.py<br><br>

**Enhanced error messages in aota_command.py to include status <br>codes and messages when unable to download docker images or <br>docker-compose containers.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/479/files#diff-8129abdf9a5964caacca6256f72c22dbea2bfb795681942725fe638dab82ca22"> +5/-3</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>application_command.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/aota/application_command.py<br><br>

**Improved error messaging in application_command.py to <br>provide detailed status and messages when failing to <br>download application packages.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/479/files#diff-9b77db73641f5adc2bba7826c3cd9319509bcb1f8143ab949cd3558da8aac362"> +2/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>package_manager.py&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/dispatcher-agent/dispatcher/packagemanager/package_manager.py<br><br>

**Added a check for None response and a fallback to a default <br>"Unknown Status Code" message in package_manager.py when an <br>HTTP error occurs without a reason.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/479/files#diff-717aa552bf5b3512a02b6aa5842fdc3404ec604808479d1062905ab69f388a6f"> +6/-2</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Changelog.md&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        inbm/Changelog.md<br><br>

**Updated the Changelog to reflect the improved error handling <br>when fetching from URLs fails.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel/intel-inb-manageability/pull/479/files#diff-27820a03e4b112340660d2cfa1442337ed849179731d7586ce8b7a52ca92298d"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of Co-Pilot generated PR Summary