### PR TITLE
(NEXARL-279) Fixed system would not be able to access secret volume after fwupd on Arrow Lake platform

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
  - Fixed some Yocto issues found after migrating to scarthgap
  - (NEXARL-195) Fixed device tree detection check on systems that implement only part of device tree
+ - (NEXARL-279) Fixed system would not be able to access secret volume after fwupd on Arrow Lake platform
 
 ### Security
  - Bump requests from 2.31.0 to 2.32.2 in multiple agents resolving detected 3rd party CVE: CVE-2024-35195

--- a/inbm/fpm/mqtt/template/usr/bin/tc-get-tpm-passphrase
+++ b/inbm/fpm/mqtt/template/usr/bin/tc-get-tpm-passphrase
@@ -33,6 +33,7 @@ cd /etc/intel-manageability/scratch
 # setup lock pass phrases with a -p password
 tpm2_startauthsession -S session.dat 1>&2
 tpm2_policypassword -S session.dat -L policy.dat 1>&2
+tpm2_flushcontext session.dat 1>&2
 
 # read existing or generate new tpm password.
 TPM_PASS_LOCATION="/etc/intel-manageability/tpm-pass.txt"


### PR DESCRIPTION
On investigation, we noticed that the TPM message saying "out of session handles". Fix is to add tpm2_flushcontext command to free handle when done.

It's unclear why this became a problem with fwupdtool/Arrow Lake, but this appears to fix it.

