### PR TITLE
Update package versions to address security vulnerabilities

### DIFF
--- a/inbc-program/requirements.txt
+++ b/inbc-program/requirements.txt
@@ -1,6 +1,6 @@
 #Production
 
 pyinstaller==5.13.1
-setuptools==65.5.1
+setuptools==70.0.0
 psutil==5.9.5
 types-psutil==5.9.5.17

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -18,7 +18,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Security
  - Bump requests from 2.31.0 to 2.32.2 in multiple agents resolving detected 3rd party CVE: CVE-2024-35195
- - Bump urllib3 from 1.26.18 to 1.26.19 in cloudadapter agent resolving detected 3rd party CVE: CVE-2024-37891
+ - Bump urllib3 from 1.26.18 to 1.26.19 in cloudadapter agent and dispatcher agent resolving detected 3rd party CVE: CVE-2024-37891
+ - Bump setuptools from 65.5.1 to 70.0.0 in multiple agents resolving detected 3rd party CVE: CVE-2024-6345
+ - Bump certifi from 2023.7.22 to 2024.07.04 in dispatcher agent resolving detected 3rd party CVE: CVE-2024-39689
+ - Bump golang-runtime from 1.20.14 to 1.22.5 in all go binaries resolving detected 3rd party CVE: CVE-2024-24790
 
 ## 4.2.3 - 2024-05-02
 

--- a/inbm/configuration-agent/requirements.txt
+++ b/inbm/configuration-agent/requirements.txt
@@ -1,4 +1,4 @@
 #Production
 
 pyinstaller==5.13.1
-setuptools==65.5.1
+setuptools==70.0.0

--- a/inbm/diagnostic-agent/requirements.txt
+++ b/inbm/diagnostic-agent/requirements.txt
@@ -4,5 +4,5 @@ psutil==5.9.5
 types-psutil==5.9.5.17
 shortuuid==1.0.1
 pyinstaller==5.13.1
-setuptools==65.5.1
+setuptools==70.0.0
 netifaces==0.11.0

--- a/inbm/dispatcher-agent/requirements.txt
+++ b/inbm/dispatcher-agent/requirements.txt
@@ -7,10 +7,10 @@ jsonschema==4.20.0
 types-jsonschema==4.20.0.0
 shortuuid==1.0.1
 requests==2.32.2
-urllib3==1.26.18
-certifi==2023.7.22
+urllib3==1.26.19
+certifi==2024.07.04
 pyinstaller==5.13.1
-setuptools==65.5.1
+setuptools==70.0.0
 future==0.18.3
 untangle==1.2.1
 APScheduler==3.10.4

--- a/inbm/dockerfiles/Dockerfile-Windows.m4
+++ b/inbm/dockerfiles/Dockerfile-Windows.m4
@@ -107,17 +107,17 @@ RUN pyinstaller inbm-cloudadapter-windows.spec && \
     wine ../cloudadapter-agent/dist/inbm-cloudadapter/inbm-cloudadapter.exe install && \
     cp -r ../cloudadapter-agent/dist/inbm-cloudadapter /output
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-certs-windows
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-certs-windows
 COPY inbm/fpm/inb-provision-certs /inb-provision-certs
 RUN cd /inb-provision-certs && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-certs/inb-provision-certs.exe /output/inb-provision-certs.exe
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-cloud-windows
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-cloud-windows
 COPY inbm/fpm/inb-provision-cloud /inb-provision-cloud
 RUN cd /inb-provision-cloud && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-cloud/inb-provision-cloud.exe /output/inb-provision-cloud.exe
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-ota-cert-windows
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-ota-cert-windows
 COPY inbm/fpm/inb-provision-ota-cert /inb-provision-ota-cert
 RUN cd /inb-provision-ota-cert && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-ota-cert/inb-provision-ota-cert.exe /output/inb-provision-ota-cert.exe

--- a/inbm/dockerfiles/Dockerfile-Windows.m4
+++ b/inbm/dockerfiles/Dockerfile-Windows.m4
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 include(`image.main.m4')
 
 # base windows/wine build image

--- a/inbm/dockerfiles/commands.base-setup.m4
+++ b/inbm/dockerfiles/commands.base-setup.m4
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # base-setup.m4: common set of commands for a base utility image, either x86 or arm
 
 SHELL ["/bin/bash", "-c"]

--- a/inbm/dockerfiles/image.ehl.m4
+++ b/inbm/dockerfiles/image.ehl.m4
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # build x86 assets
 include(`image.main.m4')
 

--- a/inbm/dockerfiles/image.main.m4
+++ b/inbm/dockerfiles/image.main.m4
@@ -1,3 +1,6 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # base image with all dependencies for building
 FROM registry.hub.docker.com/library/ubuntu:20.04 as base
 RUN echo 'force cache refresh 20240212'

--- a/inbm/dockerfiles/image.main.m4
+++ b/inbm/dockerfiles/image.main.m4
@@ -150,7 +150,7 @@ RUN source /venv-py3/bin/activate && \
 
 # ---trtl---
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as trtl-build
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as trtl-build
 WORKDIR /
 ENV GOPATH /build/go
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
@@ -178,19 +178,19 @@ RUN rm -rf /output/ && mv ./output/ /output/
 
 # --inb-provision-certs-
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-certs
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-certs
 COPY inbm/fpm/inb-provision-certs /inb-provision-certs
 RUN cd /inb-provision-certs && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-certs/inb-provision-certs /output/inb-provision-certs
 
 # --inb-provision-cloud-
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-cloud
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-cloud
 COPY inbm/fpm/inb-provision-cloud /inb-provision-cloud
 RUN cd /inb-provision-cloud && go test . && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-cloud/inb-provision-cloud /output/inb-provision-cloud
 
 # --inb-provision-ota-cert-
 
-FROM registry.hub.docker.com/library/golang:1.20-bookworm as inb-provision-ota-cert
+FROM registry.hub.docker.com/library/golang:1.22-bookworm as inb-provision-ota-cert
 COPY inbm/fpm/inb-provision-ota-cert /inb-provision-ota-cert
 RUN cd /inb-provision-ota-cert && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-ota-cert/inb-provision-ota-cert /output/inb-provision-ota-cert
 

--- a/inbm/fpm/inb-provision-certs/go.mod
+++ b/inbm/fpm/inb-provision-certs/go.mod
@@ -1,3 +1,3 @@
 module inb-provision-certs
 
-go 1.20
+go 1.22

--- a/inbm/fpm/inb-provision-cloud/go.mod
+++ b/inbm/fpm/inb-provision-cloud/go.mod
@@ -1,6 +1,6 @@
 module inb-provision-cloud
 
-go 1.20
+go 1.22
 
 require (
 	github.com/lestrrat-go/jsschema v0.0.0-20181205002244-5c81c58ffcc3

--- a/inbm/fpm/inb-provision-ota-cert/go.mod
+++ b/inbm/fpm/inb-provision-ota-cert/go.mod
@@ -1,3 +1,3 @@
 module inb-provision-ota-cert
 
-go 1.20
+go 1.22

--- a/inbm/telemetry-agent/requirements.txt
+++ b/inbm/telemetry-agent/requirements.txt
@@ -4,4 +4,4 @@ psutil==5.9.5
 types-psutil==5.9.5.17
 shortuuid==1.0.1
 pyinstaller==5.13.1
-setuptools==65.5.1
+setuptools==70.0.0

--- a/inbm/trtl/go.mod
+++ b/inbm/trtl/go.mod
@@ -1,6 +1,6 @@
 module iotg-inb/trtl
 
-go 1.20
+go 1.22
 
 require (
 	github.com/docker/docker v24.0.9+incompatible


### PR DESCRIPTION
 - Bump requests from 2.31.0 to 2.32.2 in multiple agents resolving detected 3rd party CVE: CVE-2024-35195
 - Bump urllib3 from 1.26.18 to 1.26.19 in cloudadapter agent and dispatcher agent resolving detected 3rd party CVE: CVE-2024-37891
 - Bump setuptools from 65.5.1 to 70.0.0 in multiple agents resolving detected 3rd party CVE: CVE-2024-6345
 - Bump certifi from 2023.7.22 to 2024.07.04 in dispatcher agent resolving detected 3rd party CVE: CVE-2024-39689
 - Bump golang-runtime from 1.20.14 to 1.22.5 in all go binaries resolving detected 3rd party CVE: CVE-2024-24790
