### PR TITLE
[NEXMANAGE-493] Fixed dispatcher failed to get granular log during download-only mode

### DIFF
--- a/inbm-lib/inbm_lib/package_info.py
+++ b/inbm-lib/inbm_lib/package_info.py
@@ -33,19 +33,28 @@ def extract_package_names_and_versions(text: str) -> Dict[str, str]:
 
     @return: a dict that contains package's name and its version
     """
-    # Extract the upgrade line
-    upgrade_line = [line for line in text.split('\n') if 'Upgrade:' in line][0]
-    # Use regex to split on commas not inside parentheses
-    packages = re.split(r',\s*(?![^()]*\))', upgrade_line.replace('Upgrade: ', ''))
     # Create a dictionary to store package names and their versions
     package_dict = {}
-    # Loop through each package string and extract the name and version
-    for package in packages:
-        name_version = re.match(r"(.+?)\s+\((.+)\)", package)
-        if name_version:
-            name = name_version.group(1).strip()
-            version = name_version.group(2).strip()
-            package_dict[name] = version
+    try:
+        # Extract the upgrade line
+        upgrade_lines = [line for line in text.split('\n') if 'Upgrade:' in line]
+        if upgrade_lines:
+            upgrade_line = upgrade_lines[0]
+        else:
+            raise KeyError
+        # Use regex to split on commas not inside parentheses
+        packages = re.split(r',\s*(?![^()]*\))', upgrade_line.replace('Upgrade: ', ''))
+
+        # Loop through each package string and extract the name and version
+        for package in packages:
+            name_version = re.match(r"(.+?)\s+\((.+)\)", package)
+            if name_version:
+                name = name_version.group(1).strip()
+                version = name_version.group(2).strip()
+                package_dict[name] = version
+    except (IndexError, KeyError):
+        logger.debug(f"No Upgrade Packages found in text:{text}")
+        return package_dict
     return package_dict
 
 

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  - (NEXMANAGE-259) Update status enhancements(granular package level data) in INBM
  - (NEXMANAGE-314) Fixed Cloudadapter sometimes sends INBS commands to Dispatcher before it's fully up
  - (NEXMANAGE-314) Send response immediately for immediately scheduling
+ - (NEXMANAGE-493) Fixed dispatcher error in getting granular log during download-only mode
 
 ### Fixed
  - Fixed some Yocto issues found after migrating to scarthgap

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -362,7 +362,10 @@ class SOTA:
                 if self._is_ota_no_update_available(cmd_list) and self._package_list == "":
                     # if no package upgrade/install, set the status to OTA_NO_UPDATE and skip saving the granular data.
                     self._update_logger.status = OTA_NO_UPDATE
-                else:
+                # The download-only mode only downloads the packages without installing them.
+                # Since there is no installation, there will be no changes in the package status or version.
+                # The apt history.log also doesn't record any changes. Therefore we can skip saving granular log.
+                elif self.sota_mode != 'download-only':
                     self._update_logger.save_granular_log_file()
                 if (self.sota_mode == 'download-only') or (not self._is_reboot_device()):
                     self._dispatcher_broker.telemetry("No reboot (SOTA pass)")
@@ -376,7 +379,8 @@ class SOTA:
                 self._update_logger.status = FAIL
                 self._update_logger.error = ""
                 self._update_logger.save_log()
-                self._update_logger.save_granular_log_file()
+                if self.sota_mode != 'download-only':
+                    self._update_logger.save_granular_log_file()
                 self._dispatcher_broker.telemetry(SOTA_FAILURE)
                 self._dispatcher_broker.send_result(SOTA_FAILURE)
                 raise SotaError(SOTA_FAILURE)

--- a/inbm/dispatcher-agent/tests/unit/test_update_logger.py
+++ b/inbm/dispatcher-agent/tests/unit/test_update_logger.py
@@ -103,6 +103,71 @@ class TestUpdateLogger(TestCase):
         mock_status.assert_called_once()
         self.assertEqual(granular_log, expected_content)
 
+    def test_save_granular_log_file_sota_without_package_list_without_upgrade_but_with_upgrade_keyword_in_text(self) -> None:
+        self.update_logger.ota_type = "sota"
+
+        history_content = """
+        Start-Date: 2024-08-06  06:26:14
+        Commandline: apt remove -y unattended-upgrades
+        Remove: unattended-upgrades:amd64 (2.8ubuntu1)
+        End-Date: 2024-08-06  06:26:14
+        
+        Start-Date: 2024-08-06  07:45:30
+        Commandline: /bin/apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --no-download --fix-missing -yq install intel-opencl-icd
+        Install: intel-opencl-icd:amd64 (22.14.22890-1)
+        End-Date: 2024-08-06  07:45:30
+        
+        Start-Date: 2024-08-06  08:12:35
+        Commandline: /bin/apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --no-download --fix-missing -yq install mongodb-org
+        Install: mongodb-mongosh:amd64 (2.2.15, automatic), mongodb-org-database-tools-extra:amd64 (7.0.12, automatic), mongodb-org-shell:amd64 (7.0.12, automatic), mongodb-org-database:amd64 (7.0.12, automatic), mongodb-org-server:amd64 (7.0.12, automatic), mongodb-org:amd64 (7.0.12), mongodb-org-tools:amd64 (7.0.12, automatic), mongodb-database-tools:amd64 (100.10.0, automatic), mongodb-org-mongos:amd64 (7.0.12, automatic)
+        End-Date: 2024-08-06  08:12:42
+        """
+
+        expected_content: dict = {
+                            "UpdateLog": [
+                                ]
+                            }
+
+        with open(SYSTEM_HISTORY_LOG_FILE, "w") as file:
+            file.write(history_content)
+
+        self.update_logger.save_granular_log_file()
+
+        with open(GRANULAR_LOG_FILE, 'r') as f:
+            granular_log = json.load(f)
+
+        self.assertEqual(granular_log, expected_content)
+
+    def test_save_granular_log_file_sota_without_package_list_without_update_keyword(self) -> None:
+        self.update_logger.ota_type = "sota"
+
+        history_content = """
+        Start-Date: 2024-08-06  07:45:30
+        Commandline: /bin/apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --no-download --fix-missing -yq install intel-opencl-icd
+        Install: intel-opencl-icd:amd64 (22.14.22890-1)
+        End-Date: 2024-08-06  07:45:30
+
+        Start-Date: 2024-08-06  08:12:35
+        Commandline: /bin/apt-get -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --no-download --fix-missing -yq install mongodb-org
+        Install: mongodb-mongosh:amd64 (2.2.15, automatic), mongodb-org-database-tools-extra:amd64 (7.0.12, automatic), mongodb-org-shell:amd64 (7.0.12, automatic), mongodb-org-database:amd64 (7.0.12, automatic), mongodb-org-server:amd64 (7.0.12, automatic), mongodb-org:amd64 (7.0.12), mongodb-org-tools:amd64 (7.0.12, automatic), mongodb-database-tools:amd64 (100.10.0, automatic), mongodb-org-mongos:amd64 (7.0.12, automatic)
+        End-Date: 2024-08-06  08:12:42
+        """
+
+        expected_content: dict = {
+            "UpdateLog": [
+            ]
+        }
+
+        with open(SYSTEM_HISTORY_LOG_FILE, "w") as file:
+            file.write(history_content)
+
+        self.update_logger.save_granular_log_file()
+
+        with open(GRANULAR_LOG_FILE, 'r') as f:
+            granular_log = json.load(f)
+
+        self.assertEqual(granular_log, expected_content)
+
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', side_effect=[("install ok installed", "", 0),
                                                                               ("1:26.3+1-1ubuntu2", "", 0)])
     def test_save_granular_log_file_sota_with_package_list(self, mock_run) -> None:

--- a/inbm/packaging/yocto/common/usr.bin.inbm-dispatcher
+++ b/inbm/packaging/yocto/common/usr.bin.inbm-dispatcher
@@ -146,5 +146,6 @@
   /var/log/inbm-update-log.log rw,
   /var/log/apt/history.log r,
   /var/volatile/log/inbm-update-status.log rw,
+  /var/volatile/log/inbm-update-log.log rw,
   /usr/bin/UpdateFirmwareBlobFwupdtool.sh rUx,
 }


### PR DESCRIPTION
_The PR review is to check for sustainability and correctness.  Sustainability is actually more business critical as correctness is largely tested into the code over time.   Its useful to keep in mind that SW often outlives the HW it was written for and engineers move from job to job so it is critical that code developed for Intel be supportable across many years.  It is up to the submitter and reviewer to look at the code from a perspective of what if we have to debug this 3 years from now after the author is no longer available and defect databases have been lost.  Yes, that happens all the time when we are working with time scales of more than 2 years.  When reviewing your code it is important to look at it from this perspective._

Author Mandatory (to be filled by PR Author/Submitter)
------------------------------------------------------
- Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.  
- Those checklist items which are not marked are considered as not applicable for the PR change.  
- Items marked with an asterisk suffix are mandatory items to check and if not marked will be treated as non-compliant pull requests by the developers for Inner Source Development Model (ISDM) compliance

### PULL DESCRIPTION
During download-only mode, there are no package installations. The dispatcher agent failed to retrieve the package information from history.log. This PR fixes the issue by instructing the dispatcher agent not to write the granular log if it is in download-only mode. Additionally, this PR includes the exception handling to address the corner cases in history.log, such as when no upgrade package has been found.

### REFERENCES
Reference URL for issue tracking (JIRA/HSD/Github): **\<URL to be filled>**
- [x] **_Added label to the Pull Request following the template: ISDM\_\<Complexity>\*_** \
	Note-1: Depending on complexity of code changes, use the suitable word for complexity: Low/Medium/High \
	Example: PR for Slim boot loader project with medium complexity can have the label as: ISDM_Medium	
- [x] Added label to the Pull Request for easier discoverability and search
- [x] RTC or HSD number will be included in final merge. HSD must always be included if available.
- [x] Changelogs are updated (or N/A if not customer visible)
- [ ] inbm/log_changes.txt are updated for potentially Validation-breaking log changes (or N/A if none)

### CODE MAINTAINABILITY
- [x] **_Commit Message meets guidelines as indicated in the URL\*_**
	- (https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md)
- [x] **_Every commit is a single defect fix and does not mix feature addition or changes\*_**
- [x] Added required new tests relevant to the changes
	- [ ] PR contains URL links to functional tests executed with the new tests 
- [ ] Updated Documentation as relevant to the changes
- [ ] Updated Build steps/commands changes as relevant
- [ ] PR change contains code related to security
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide description)
- [ ] Specific instructions or information for code reviewers (If any):
- [ ] Run 'go fmt' or format-python.sh as applicable.
- [ ] New/modified methods and functions should have type annotations on signatures as applicable
- [ ] New/modified methods must have appropriate doc strings (language dependent)

### APPLICATION SPECIFIC
- [ ] Does PR change default config files under /etc? If so, will application still work after an upgrade that leaves /etc alone, like a Mender upgrade?
- [ ] Is cloud UI changed? If so, are cloud definition files updated?



Maintainer Mandatory (to be filled by PR Reviewer/Approving Maintainer)
-----------------------------------------------------------------------
- Maintainer who approves the Pull Request for merge is required to mark the checklist below as appropriate for the PR change reviewed as key proof of attestation indicating reasons for merge. 
- Those checklist items which are not marked are considered as not applicable for the PR change. 
- Items marked with an asterisk suffix are mandatory items to check and if not marked will be treated as non-compliant pull requests by the maintainers for ISDM compliance.

### QUALITY CHECKS
- [ ] Architectural and Design Fit
- [ ] **_Quality of code (At least one should be checked as applicable)\*_**
	- [ ] Commit Message meets guidelines
	- [ ] PR changes adhere to industry practices and standards
	- [ ] Error and exception code paths implemented correctly
	- [ ] Code reviewed for domain or language specific anti-patterns
	- [ ] Code is adequately commented
	- [ ] Code copyright is correct
	- [ ] Confusing logic is explained in comments
	- [ ] Commit comment can be used to design a new test case for the changes
- [ ] **_Test coverage shows adequate coverage with required CI functional tests pass on all supported platforms\*_**
- [ ] **_Static code scan report shows zero critical issues\*_**
- [ ] Integration tests are passing

### CODE REVIEW IMPACT
- Summary of Defects Detected in Code Review: **\<%P1*xx,P2*xx,P3*xx,P4*xx%>** \
Note P1/P2/P3/P4 denotes severity of defects found (Showstopper/High/Medium/Low) and xx denotes number of defects found

### SECURITY CHECKS
Please check if your PR fulfills the following requirements:

- [ ] Follow best practices when handling primitive data types
- [ ] Configure minimal permissions when opening pipes and ports
- [ ] Check contents within input structures are valid before use
- [ ] All forms of input validated
- [ ] Avoid inter-process race conditions
- [ ] Error and exception handling implemented
- [ ] Defend against Canonical Representation Issues - Any paths utilized?
- [ ] Follow 'secure by default' - Any configuration values added
- [ ] Fail safe - Any failure scenarios?
- [ ] Clean up temporary files - Any temporary files being used?

# _Code must act as a teacher for future developers_
