### PR TITLE
WIP: [NEXMANAGE-737] Enable sota cancel mode.

### DIFF
--- a/inbc-program/inbc/parser/parser.py
+++ b/inbc-program/inbc/parser/parser.py
@@ -222,7 +222,7 @@ class ArgsParser(object):
         parser_sota.add_argument('--reboot', '-rb', default='yes', required=False, choices=['yes', 'no'],
                                  help='Type of information [ yes | no ]')
         parser_sota.add_argument('--mode', '-m', default='full',
-                                 required=False, choices=['full', 'download-only', 'no-download'])
+                                 required=False, choices=['full', 'download-only', 'no-download', 'cancel'])
         parser_sota.add_argument('--package-list', '-p', required=False,
                                  type=lambda x: validate_package_list(x),
                                  help='Comma-separated list of package names to install')

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  - Updated proto files to add new RPC calls to allow edge node to update
    its status with INBS.
  - (NEXMANAGE- 610) Add functionality to INBM Cloudadapter-agent to support OOB AMT RPC command requests from INBS
+ - (NEXMANAGE-737) Enable sota cancel mode
 
 ### Changed
  - (NEXARL-306) Update agents' prerm script to prevent them from disabling and stopping if it's an upgrade process

--- a/inbm/dispatcher-agent/dispatcher/sota/cancel.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/cancel.py
@@ -49,3 +49,23 @@ def cancel_thread(type_of_manifest: str, parsed_head: XmlHandler, thread_list: l
                             logger.error(e)
                 return True
     return False
+
+
+def is_active_ota_sota_download_only(type_of_active_manifest: str, active_parsed_head: XmlHandler) -> bool:
+    """
+    Check whether the current active thread is SOTA download-only mode.
+
+    @param type_of_active_manifest: type of the request
+    @param active_parsed_head: The root parsed xml
+    @return: True if it is SOTA download-only; False if not.
+    """
+    logger.debug("")
+    if type_of_active_manifest == 'ota':
+        header = active_parsed_head.get_children('ota/header')
+        ota_type = header['type']
+        resource = active_parsed_head.get_children(f'ota/type/{ota_type}')
+        if ota_type == OtaType.SOTA.name.lower():
+            sota_mode = resource.get('mode', None)
+            if sota_mode == 'download-only':
+                return True
+    return False

--- a/inbm/dispatcher-agent/dispatcher/sota/cancel.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/cancel.py
@@ -1,0 +1,51 @@
+"""
+    Method to handle cancel request
+
+    Copyright (C) 2017-2024 Intel Corporation
+    SPDX-License-Identifier: Apache-2.0
+"""
+
+import logging
+import signal
+from inbm_lib.xmlhandler import XmlHandler
+from threading import Thread
+from .constants import SOTA_CACHE
+from ..constants import OtaType
+from dispatcher.dispatcher_exception import DispatcherException
+from dispatcher.packagemanager.local_repo import DirectoryRepo
+
+logger = logging.getLogger(__name__)
+
+
+def cancel_thread(type_of_manifest: str, parsed_head: XmlHandler, thread_list: list[Thread]) -> bool:
+    """
+    Cancel the current active thread by sending the terminate signal.
+
+    @param type_of_manifest: type of the request
+    @param parsed_head: The root parsed xml
+    @param thread_list: List of the active thread
+    @return: True if the request has been processed; False if no request has been handled.
+    """
+
+    if type_of_manifest == 'ota':
+        header = parsed_head.get_children('ota/header')
+        ota_type = header['type']
+        resource = parsed_head.get_children(f'ota/type/{ota_type}')
+        if ota_type == OtaType.SOTA.name.lower():
+            sota_mode = resource.get('mode', None)
+            if sota_mode == 'cancel':
+                logger.debug(f"Receive sota cancel request.")
+                # The list should only contain one OTA process.
+                for thread in thread_list:
+                    if thread.is_alive() and thread.ident:
+                        logger.debug(f"Terminate thread={thread.ident}.")
+                        signal.pthread_kill(thread.ident, signal.SIGTERM)
+                        # Remove the repo after killing the thread
+                        try:
+                            sota_cache_repo = DirectoryRepo(SOTA_CACHE)
+                            sota_cache_repo.delete_all()
+                        except DispatcherException as e:
+                            # If the directory doesn't exist, print the error.
+                            logger.error(e)
+                return True
+    return False

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import time
+import signal
 from typing import Any, List, Optional, Union, Mapping
 
 from inbm_common_lib.exceptions import UrlSecurityException

--- a/inbm/dispatcher-agent/fpm-template/usr/share/dispatcher-agent/manifest_schema.xsd
+++ b/inbm/dispatcher-agent/fpm-template/usr/share/dispatcher-agent/manifest_schema.xsd
@@ -460,6 +460,7 @@
             <xs:enumeration value="full"/>
             <xs:enumeration value="no-download"/>
             <xs:enumeration value="download-only"/>
+            <xs:enumeration value="cancel"/>
     	</xs:restriction>
     </xs:simpleType>
 

--- a/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
@@ -5,7 +5,7 @@ import threading
 from time import sleep
 from inbm_lib.xmlhandler import XmlHandler
 
-from dispatcher.sota.cancel import cancel_thread
+from dispatcher.sota.cancel import cancel_thread, is_active_ota_sota_download_only
 
 TEST_SCHEMA_LOCATION = os.path.join(os.path.dirname(__file__),
                                     '../../../fpm-template/usr/share/dispatcher-agent/'
@@ -37,3 +37,27 @@ class TestCancelThread(unittest.TestCase):
 
         self.assertTrue(cancel_thread(type_of_manifest, parsed_head, thread_list))
         mock_kill.assert_called_once()
+
+    def test_is_active_ota_sota_download_only_return_true(self) -> None:
+
+        sota_download_only_manifest = """<?xml version="1.0" encoding="utf-8"?><manifest><type>ota</type><ota><header>
+        <type>sota</type><repo>remote</repo></header><type><sota><cmd logtofile="y">update</cmd>
+        <mode>download-only</mode><package_list></package_list><deviceReboot>yes</deviceReboot>
+        </sota></type></ota></manifest> """
+
+        type_of_manifest = "ota"
+        parsed_head = XmlHandler(sota_download_only_manifest, is_file=False, schema_location=TEST_SCHEMA_LOCATION)
+
+        self.assertTrue(is_active_ota_sota_download_only(type_of_manifest, parsed_head))
+
+    def test_is_active_ota_sota_download_only_return_false(self) -> None:
+
+        sota_download_only_manifest = """<?xml version="1.0" encoding="utf-8"?><manifest><type>ota</type><ota><header>
+        <type>sota</type><repo>remote</repo></header><type><sota><cmd logtofile="y">update</cmd>
+        <mode>no-download</mode><package_list></package_list><deviceReboot>yes</deviceReboot>
+        </sota></type></ota></manifest> """
+
+        type_of_manifest = "ota"
+        parsed_head = XmlHandler(sota_download_only_manifest, is_file=False, schema_location=TEST_SCHEMA_LOCATION)
+
+        self.assertFalse(is_active_ota_sota_download_only(type_of_manifest, parsed_head))

--- a/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch, Mock
+import os
+import threading
+from time import sleep
+from inbm_lib.xmlhandler import XmlHandler
+
+from dispatcher.sota.cancel import cancel_thread
+
+TEST_SCHEMA_LOCATION = os.path.join(os.path.dirname(__file__),
+                                    '../../../fpm-template/usr/share/dispatcher-agent/'
+                                    'manifest_schema.xsd')
+
+
+class TestCancelThread(unittest.TestCase):
+
+    @patch('signal.pthread_kill')
+    def test_cancel_thread_success(self, mock_kill) -> None:
+        # We can't send the signal to kill the thread here. The signal will be sent to unit test main thread.
+        def mock_thread():
+            sleep(10)
+
+        sota_cancel_manifest = """<?xml version="1.0" encoding="utf-8"?><manifest><type>ota</type><ota><header>
+        <type>sota</type><repo>remote</repo></header><type><sota><cmd logtofile="y">update</cmd>
+        <mode>cancel</mode><package_list></package_list><deviceReboot>yes</deviceReboot>
+        </sota></type></ota></manifest> """
+
+        type_of_manifest = "ota"
+        thread_list = []
+
+        worker = threading.Thread(target=mock_thread)
+        worker.setDaemon(True)
+        thread_list.append(worker)
+        worker.start()
+        sleep(1)
+        parsed_head = XmlHandler(sota_cancel_manifest, is_file=False, schema_location=TEST_SCHEMA_LOCATION)
+
+        self.assertTrue(cancel_thread(type_of_manifest, parsed_head, thread_list))
+        mock_kill.assert_called_once()


### PR DESCRIPTION

<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

This PR implements the sota cancel mode. When the thread is created, it will be added  to a thread list.
When the dispatcher receives the sota cancel request, the dispatcher checks the current running thread and retrieves its id. Next, it sends a termination signal to the thread.



### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [ ] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
