### PR TITLE
Update the name of TiberOS to "tiber"

### DIFF
--- a/inbm-lib/inbm_lib/detect_os.py
+++ b/inbm-lib/inbm_lib/detect_os.py
@@ -35,7 +35,7 @@ class LinuxDistType(Enum):
     Debian = 4
     CentOS = 5
     Mariner = 6  # TODO: Remove this when confirmed that TiberOS is in use
-    TiberOS = 7
+    tiber = 7
 
 
 def verify_os_supported() -> str:

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
  - Updated proto files to add new RPC calls to allow edge node to update
    its status with INBS.
  - (NEXMANAGE- 610) Add functionality to INBM Cloudadapter-agent to support OOB AMT RPC command requests from INBS
+ - Update TiberOS name to "tiber"
 
 ### Changed
  - (NEXARL-306) Update agents' prerm script to prevent them from disabling and stopping if it's an upgrade process

--- a/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/os_factory.py
@@ -79,7 +79,7 @@ class SotaOsFactory:
         elif os_type == LinuxDistType.Mariner.name:
             logger.debug("Mariner returned")
             return TiberOSBasedSotaOs(self._dispatcher_broker, self._signature)
-        elif os_type == LinuxDistType.TiberOS.name:
+        elif os_type == LinuxDistType.tiber.name:
             logger.debug("TiberOS returned")
             return TiberOSBasedSotaOs(self._dispatcher_broker, self._signature)
         raise ValueError('Unsupported OS type: ' + os_type)

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -392,7 +392,7 @@ class SOTA:
                 # the artifacts from the OCI registry. The granular log is enabled in TiberOS with the download-only
                 # mode here to record the successful SOTA with current os version.
                 # TODO: Remove Mariner when confirmed that TiberOS is in use
-                elif detect_os() == LinuxDistType.TiberOS.name or detect_os() == LinuxDistType.Mariner.name:
+                elif detect_os() == LinuxDistType.tiber.name or detect_os() == LinuxDistType.Mariner.name:
                     self.save_granular_log()
 
                 # The download-only mode only downloads the packages without installing them.
@@ -417,7 +417,7 @@ class SOTA:
                 # the artifacts from the OCI registry. The granular log is enabled in TiberOS with the download-only
                 # mode because we want to record the artifact download failure.
                 # TODO: Remove Mariner when confirmed that TiberOS is in use
-                if detect_os() == LinuxDistType.TiberOS.name or detect_os() == LinuxDistType.Mariner.name:
+                if detect_os() == LinuxDistType.tiber.name or detect_os() == LinuxDistType.Mariner.name:
                     self.save_granular_log()
                 elif self.sota_mode != 'download-only':
                     self.save_granular_log()
@@ -451,7 +451,7 @@ class SOTA:
         current_os = detect_os()
         # TODO: Remove Mariner when confirmed that TiberOS is in use
         with self._granular_lock:
-            if current_os == LinuxDistType.TiberOS.name or current_os == LinuxDistType.Mariner.name:
+            if current_os == LinuxDistType.tiber.name or current_os == LinuxDistType.Mariner.name:
                 # Delete the previous log if exist.
                 if os.path.exists(GRANULAR_LOG_FILE):
                     remove_file(GRANULAR_LOG_FILE)

--- a/inbm/dispatcher-agent/tests/unit/sota/test_downloader.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_downloader.py
@@ -126,7 +126,7 @@ class TestDownloader(unittest.TestCase):
 
         assert isinstance(TestDownloader.sota_instance, SOTA)
         TestDownloader.sota_instance.factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
         factory = TestDownloader.sota_instance.factory
         assert isinstance(factory, TiberOSBasedSotaOs)
         installer = factory.create_downloader()
@@ -153,7 +153,7 @@ class TestDownloader(unittest.TestCase):
         password = "mock_password"
         assert isinstance(TestDownloader.sota_instance, SOTA)
         TestDownloader.sota_instance.factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
         factory = TestDownloader.sota_instance.factory
         assert isinstance(factory, TiberOSBasedSotaOs)
         installer = factory.create_downloader()

--- a/inbm/dispatcher-agent/tests/unit/sota/test_oras_util.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_oras_util.py
@@ -73,7 +73,7 @@ class TestDownloader(unittest.TestCase):
                                  None,
                                  install_check_service=MockInstallCheckService())
         cls.sota_instance.factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
 
     @patch("inbm_common_lib.shell_runner.PseudoShellRunner.run", return_value=('200', "", 0))
     @patch('json.loads', return_value=mock_resp)
@@ -89,7 +89,7 @@ class TestDownloader(unittest.TestCase):
 
         assert TestDownloader.sota_instance
         TestDownloader.sota_instance.factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
         factory = TestDownloader.sota_instance.factory
         assert factory
         installer = factory.create_downloader()

--- a/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_os_factory.py
@@ -29,7 +29,7 @@ class TestOsFactory(TestCase):
         assert type(SotaOsFactory(self.mock_disp_broker).get_os('Windows')) is Windows
 
     def test_get_factory_tiberos(self) -> None:
-        assert type(SotaOsFactory(self.mock_disp_broker).get_os('TiberOS')) is TiberOSBasedSotaOs
+        assert type(SotaOsFactory(self.mock_disp_broker).get_os('tiber')) is TiberOSBasedSotaOs
 
     def test_raise_error_unsupported_OsFactory(self) -> None:
         factory = SotaOsFactory(self.mock_disp_broker)

--- a/inbm/dispatcher-agent/tests/unit/sota/test_setup_helper.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_setup_helper.py
@@ -87,7 +87,7 @@ class TestSetupHelper(unittest.TestCase):
     @patch('os.path.isfile', return_value=True)
     def test_tiberos_pre_processing_update_tool_exist(self, mock_is_ut_file_exists) -> None:
         factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
         setup_helper = factory.create_setup_helper()
         self.assertTrue(setup_helper.pre_processing())
         mock_is_ut_file_exists.assert_called_once()
@@ -95,7 +95,7 @@ class TestSetupHelper(unittest.TestCase):
     @patch('os.path.isfile', return_value=False)
     def test_tiberos_pre_processing_update_tool_not_exist(self, mock_is_ut_file_exists) -> None:
         factory = SotaOsFactory(
-            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('TiberOS')
+            MockDispatcherBroker.build_mock_dispatcher_broker(), None, []).get_os('tiber')
         setup_helper = factory.create_setup_helper()
         self.assertFalse(setup_helper.pre_processing())
         mock_is_ut_file_exists.assert_called_once()

--- a/inbm/dispatcher-agent/tests/unit/sota/test_sota.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_sota.py
@@ -277,11 +277,11 @@ Processing triggers for systemd (245.4-4ubuntu3.23) ...
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('dispatcher.sota.sota.get_os_version', return_value='2.0.20240802.0213')
-    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("TiberOS", "", 0))
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
     def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
         TestSota.sota_instance.factory = SotaOsFactory(
             TestSota.mock_disp_broker,
-            None, []).get_os('TiberOS')
+            None, []).get_os('tiber')
 
         TestSota.sota_instance._update_logger.detail_status = OTA_SUCCESS
 
@@ -303,11 +303,11 @@ Processing triggers for systemd (245.4-4ubuntu3.23) ...
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('dispatcher.sota.sota.get_os_version', return_value='2.0.20240802.0213')
-    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("TiberOS", "", 0))
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
     def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
         TestSota.sota_instance.factory = SotaOsFactory(
             TestSota.mock_disp_broker,
-            None, []).get_os('TiberOS')
+            None, []).get_os('tiber')
 
         TestSota.sota_instance._update_logger.detail_status = OTA_PENDING
 
@@ -327,11 +327,11 @@ Processing triggers for systemd (245.4-4ubuntu3.23) ...
 
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
-    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("TiberOS", "", 0))
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
     def test_save_granular_in_tiberos_with_fail_log(self, mock_run, mock_load, mock_dump) -> None:
         TestSota.sota_instance.factory = SotaOsFactory(
             TestSota.mock_disp_broker,
-            None, []).get_os('TiberOS')
+            None, []).get_os('tiber')
 
         TestSota.sota_instance._update_logger.detail_status = FAIL
         TestSota.sota_instance._update_logger.error = 'Error getting artifact size from https://registry-rs.internal.ledgepark.intel.com/v2/one-intel-edge/tiberos/manifests/latest using token'
@@ -353,11 +353,11 @@ Processing triggers for systemd (245.4-4ubuntu3.23) ...
 
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
-    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("TiberOS", "", 0))
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
     def test_save_granular_in_tiberos_with_rollback_log(self, mock_run, mock_load, mock_dump) -> None:
         TestSota.sota_instance.factory = SotaOsFactory(
             TestSota.mock_disp_broker,
-            None, []).get_os('TiberOS')
+            None, []).get_os('tiber')
 
         TestSota.sota_instance._update_logger.detail_status = ROLLBACK
         TestSota.sota_instance._update_logger.error = 'FAILED INSTALL: System has not been properly updated; reverting..'

--- a/inbm/dispatcher-agent/tests/unit/test_update_logger.py
+++ b/inbm/dispatcher-agent/tests/unit/test_update_logger.py
@@ -197,7 +197,7 @@ class TestUpdateLogger(TestCase):
         assert mock_run.call_count == 2
         self.assertEqual(granular_log, expected_content)
 
-    @patch('dispatcher.update_logger.detect_os', return_value='TiberOS')
+    @patch('dispatcher.update_logger.detect_os', return_value='tiber')
     def test_save_granular_log_file_sota_with_tiberos_and_log(self, mock_os) -> None:
         self.update_logger.ota_type = "sota"
         self.update_logger._time = datetime.datetime(2024, 7, 3, 1, 50, 55, 935223)


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION
In recent TiberOS image (20241002.2200), the name has been changed to "tiber". 
Update the name of TiberOS to "tiber".


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
