### PR TITLE
Extract granular log handler from SOTA and fix mocking in unit tests

### DIFF
--- a/inbm/dispatcher-agent/dispatcher/sota/granular_log_handler.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/granular_log_handler.py
@@ -1,0 +1,51 @@
+"""
+    Copyright (C) 2017-2024 Intel Corporation
+    SPDX-License-Identifier: Apache-2.0
+"""
+
+import logging
+import os
+import threading
+
+from inbm_common_lib.utility import remove_file, get_os_version
+from inbm_lib.detect_os import detect_os, LinuxDistType
+from inbm_lib.constants import OTA_PENDING, FAIL, OTA_SUCCESS, ROLLBACK, GRANULAR_LOG_FILE
+
+from ..update_logger import UpdateLogger
+
+logger = logging.getLogger(__name__)
+
+class GranularLogHandler:
+    def __init__(self) -> None:
+        self._granular_lock = threading.Lock()
+
+    def save_granular_log(self, update_logger: UpdateLogger, check_package: bool = True) -> None:
+        """Save the granular log.
+        In Ubuntu, it saves the package level information.
+        In TiberOS, it saves the detail of the SOTA update.
+
+        @param check_package: True if you want to check the package's status and version and record them in Ubuntu.
+        """
+        log = {}
+        current_os = detect_os()
+        # TODO: Remove Mariner when confirmed that TiberOS is in use
+        with self._granular_lock:
+            if current_os == LinuxDistType.tiber.name or current_os == LinuxDistType.Mariner.name:
+                # Delete the previous log if exist.
+                if os.path.exists(GRANULAR_LOG_FILE):
+                    remove_file(GRANULAR_LOG_FILE)
+
+                if update_logger.detail_status == FAIL or update_logger.detail_status == ROLLBACK:
+                    log = {
+                        "StatusDetail.Status": update_logger.detail_status,
+                        "FailureReason": update_logger.error
+                    }
+                elif update_logger.detail_status == OTA_SUCCESS or update_logger.detail_status == OTA_PENDING:
+                    log = {
+                        "StatusDetail.Status": update_logger.detail_status,
+                        "Version": get_os_version()
+                    }
+                # In TiberOS, no package level information needed.
+                update_logger.save_granular_log_file(log=log, check_package=False)
+            else:
+                update_logger.save_granular_log_file(check_package=check_package)

--- a/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
@@ -1,0 +1,101 @@
+"""
+    Copyright (C) 2017-2024 Intel Corporation
+    SPDX-License-Identifier: Apache-2.0
+"""
+
+import testtools
+from unittest.mock import patch, mock_open
+
+from dispatcher.sota.granular_log_handler import GranularLogHandler
+from dispatcher.update_logger import UpdateLogger
+from inbm_lib.constants import OTA_SUCCESS, OTA_PENDING, FAIL, ROLLBACK
+
+class TestGranularLogHandler(testtools.TestCase):
+    @patch('json.dump')
+    @patch('json.load', return_value={"UpdateLog":[]})
+    @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
+    def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
+        update_logger = UpdateLogger("SOTA", "metadata")
+        update_logger.detail_status = OTA_SUCCESS
+
+        with patch('builtins.open', mock_open()) as m_open:
+            GranularLogHandler().save_granular_log(update_logger=update_logger, check_package=False)
+
+        expected_content = {
+            "UpdateLog": [
+                {
+                    "StatusDetail.Status": OTA_SUCCESS,
+                    "Version": '2.0.20240802.0213'
+                }
+            ]
+        }
+
+        mock_dump.assert_called_with(expected_content, m_open(), indent=4)
+
+
+    @patch('json.dump')
+    @patch('json.load', return_value={"UpdateLog":[]})
+    @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')    
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
+    def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
+        update_logger = UpdateLogger("SOTA", "metadata")
+        update_logger.detail_status = OTA_PENDING
+
+        with patch('builtins.open', mock_open()) as m_open:
+            GranularLogHandler().save_granular_log(update_logger=update_logger, check_package=False)
+
+        expected_content = {
+            "UpdateLog": [
+                {
+                    "StatusDetail.Status": OTA_PENDING,
+                    "Version": '2.0.20240802.0213'
+                }
+            ]
+        }
+
+        mock_dump.assert_called_with(expected_content, m_open(), indent=4)
+
+    @patch('json.dump')
+    @patch('json.load', return_value={"UpdateLog":[]})
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
+    def test_save_granular_in_tiberos_with_fail_log(self, mock_run, mock_load, mock_dump) -> None:
+        update_logger = UpdateLogger("SOTA", "metadata")
+        update_logger.detail_status = FAIL
+        update_logger.error = 'Error getting artifact size from https://registry-rs.internal.ledgepark.intel.com/v2/one-intel-edge/tiberos/manifests/latest using token'
+
+        with patch('builtins.open', mock_open()) as m_open:
+            GranularLogHandler().save_granular_log(update_logger=update_logger, check_package=False)
+
+        expected_content = {
+            "UpdateLog": [
+                {
+                    "StatusDetail.Status": FAIL,
+                    "FailureReason": 'Error getting artifact size from https://registry-rs.internal.ledgepark.intel.com/v2/one-intel-edge/tiberos/manifests/latest using token'
+                }
+            ]
+        }
+
+        mock_dump.assert_called_with(expected_content, m_open(), indent=4)
+
+
+    @patch('json.dump')
+    @patch('json.load', return_value={"UpdateLog":[]})
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
+    def test_save_granular_in_tiberos_with_rollback_log(self, mock_run, mock_load, mock_dump) -> None:
+        update_logger = UpdateLogger("SOTA", "metadata")
+        update_logger.detail_status = ROLLBACK
+        update_logger.error = 'FAILED INSTALL: System has not been properly updated; reverting..'
+        with patch('builtins.open', mock_open()) as m_open:
+            GranularLogHandler().save_granular_log(update_logger=update_logger, check_package=False)
+
+        expected_content = {
+            "UpdateLog": [
+                {
+                    "StatusDetail.Status": ROLLBACK,
+                    "FailureReason": 'FAILED INSTALL: System has not been properly updated; reverting..'
+                }
+            ]
+        }
+
+        mock_dump.assert_called_with(expected_content, m_open(), indent=4)

--- a/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
@@ -11,11 +11,13 @@ from dispatcher.update_logger import UpdateLogger
 from inbm_lib.constants import OTA_SUCCESS, OTA_PENDING, FAIL, ROLLBACK
 
 class TestGranularLogHandler(testtools.TestCase):
+    @patch('dispatcher.sota.granular_log_handler.remove_file')
+    @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
+    def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_os_version, mock_load, mock_dump, mock_exists, mock_remove_file) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = OTA_SUCCESS
 
@@ -34,11 +36,13 @@ class TestGranularLogHandler(testtools.TestCase):
         mock_dump.assert_called_with(expected_content, m_open(), indent=4)
 
 
+    @patch('dispatcher.sota.granular_log_handler.remove_file')
+    @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')    
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_os_version, mock_load, mock_dump) -> None:
+    def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_os_version, mock_load, mock_dump, mock_exists, mock_remove_file) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = OTA_PENDING
 
@@ -56,10 +60,12 @@ class TestGranularLogHandler(testtools.TestCase):
 
         mock_dump.assert_called_with(expected_content, m_open(), indent=4)
 
+    @patch('dispatcher.sota.granular_log_handler.remove_file')
+    @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_fail_log(self, mock_run, mock_load, mock_dump) -> None:
+    def test_save_granular_in_tiberos_with_fail_log(self, mock_run, mock_load, mock_dump, mock_exists, mock_remove_file) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = FAIL
         update_logger.error = 'Error getting artifact size from https://registry-rs.internal.ledgepark.intel.com/v2/one-intel-edge/tiberos/manifests/latest using token'
@@ -79,10 +85,12 @@ class TestGranularLogHandler(testtools.TestCase):
         mock_dump.assert_called_with(expected_content, m_open(), indent=4)
 
 
+    @patch('dispatcher.sota.granular_log_handler.remove_file')
+    @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_rollback_log(self, mock_run, mock_load, mock_dump) -> None:
+    def test_save_granular_in_tiberos_with_rollback_log(self, mock_run, mock_load, mock_dump, mock_exists, mock_remove_file) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = ROLLBACK
         update_logger.error = 'FAILED INSTALL: System has not been properly updated; reverting..'

--- a/inbm/dockerfiles/Dockerfile-check.m4
+++ b/inbm/dockerfiles/Dockerfile-check.m4
@@ -121,7 +121,7 @@ RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
     export PYTHONPATH=$PYTHONPATH:$(pwd) && \
-    pytest --timeout=10 -n 1 --cov=diagnostic --cov-report=term-missing --cov-fail-under=81 tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt
+    pytest --timeout=10 -n 1 --cov=diagnostic --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt
 
 # ---dispatcher agent---
 
@@ -151,7 +151,7 @@ RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
     export PYTHONPATH=$PYTHONPATH:$(pwd) && \
-    pytest --timeout=10 -n 3 --cov=dispatcher --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt
+    pytest --timeout=10 -n 3 --cov=dispatcher --cov-report=term-missing --cov-fail-under=81 tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt
 
 # ---cloudadapter agent---
 

--- a/inbm/dockerfiles/Dockerfile-check.m4
+++ b/inbm/dockerfiles/Dockerfile-check.m4
@@ -151,7 +151,7 @@ RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
     export PYTHONPATH=$PYTHONPATH:$(pwd) && \
-    pytest --timeout=10 -n 3 --cov=dispatcher --cov-report=term-missing --cov-fail-under=81 tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt
+    pytest --timeout=10 -n 3 --cov=dispatcher --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/dispatcher-coverage.txt
 
 # ---cloudadapter agent---
 

--- a/inbm/dockerfiles/Dockerfile-check.m4
+++ b/inbm/dockerfiles/Dockerfile-check.m4
@@ -121,7 +121,7 @@ RUN source /venv-py3/bin/activate && \
     mkdir -p /output/coverage && \
     set -o pipefail && \
     export PYTHONPATH=$PYTHONPATH:$(pwd) && \
-    pytest --timeout=10 -n 1 --cov=diagnostic --cov-report=term-missing --cov-fail-under=80 tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt
+    pytest --timeout=10 -n 1 --cov=diagnostic --cov-report=term-missing --cov-fail-under=81 tests/unit 2>&1 | tee /output/coverage/diagnostic-coverage.txt
 
 # ---dispatcher agent---
 


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

This PR extracts a 'granular log handler' from `sota.py` and fixes mocking of its unit tests so
they will run as non-root. Previously, they were trying to modify files under `/var/...`. 


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | docker test container runs tests as root  |
| Jira ticket | |


### CODE MAINTAINABILITY

- [x] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [x] Run `go fmt` or `format-python.sh` as applicable
- [ ] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
