### PR TITLE
[NEXMANAGE-846] Fix granular log raise error when granular log file is empty

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## NEXT - MMMM-DD-YY
 ### Fixed
  - (NEXMANAGE-872) Fix provision-tc issue in TiberOS - cannot overwrite /etc/dispatcher.environment
+ - (NEXMANAGE-846) Fix granular log raise error when granular log file is empty
 
 ### Changed
  - (NEXMANAGE-874) Remove UT rollback command in dispatcher agent

--- a/inbm/dispatcher-agent/dispatcher/update_logger.py
+++ b/inbm/dispatcher-agent/dispatcher/update_logger.py
@@ -94,21 +94,24 @@ class UpdateLogger:
         """
         logger.debug("")
         # If the granular log file doesn't exist, create it. The file will be deleted by PUA when update done/failed.
-        if not os.path.exists(GRANULAR_LOG_FILE):
-            logger.debug(f"File not exist. Creating the {GRANULAR_LOG_FILE}...")
-            data: Dict[str, List[Any]] = {
-                "UpdateLog": []
-            }
-            with open(GRANULAR_LOG_FILE, "w") as file:
-                json.dump(data, file)
-        # Check if the file is empty. If it's empty, create the template.
-        elif os.path.getsize(GRANULAR_LOG_FILE) == 0:
-            logger.debug(f"File {GRANULAR_LOG_FILE} exists but is empty. Creating template...")
-            template: Dict[str, List[Any]] = {
-                "UpdateLog": []
-            }
-            with open(GRANULAR_LOG_FILE, "w") as file:
-                json.dump(template, file)
+        try:
+            if not os.path.exists(GRANULAR_LOG_FILE):
+                logger.debug(f"File not exist. Creating the {GRANULAR_LOG_FILE}...")
+                data: Dict[str, List[Any]] = {
+                    "UpdateLog": []
+                }
+                with open(GRANULAR_LOG_FILE, "w") as file:
+                    json.dump(data, file)
+            # Check if the file is empty. If it's empty, create the template.
+            elif os.path.getsize(GRANULAR_LOG_FILE) == 0:
+                logger.debug(f"File {GRANULAR_LOG_FILE} exists but is empty. Creating template...")
+                template: Dict[str, List[Any]] = {
+                    "UpdateLog": []
+                }
+                with open(GRANULAR_LOG_FILE, "w") as file:
+                    json.dump(template, file)
+        except OSError as e:
+            logger.error(f"OSError happens while saving granular log: {e}")
 
         if log:
             self.update_granular_with_log(log)

--- a/inbm/dispatcher-agent/dispatcher/update_logger.py
+++ b/inbm/dispatcher-agent/dispatcher/update_logger.py
@@ -101,6 +101,15 @@ class UpdateLogger:
             }
             with open(GRANULAR_LOG_FILE, "w") as file:
                 json.dump(data, file)
+        # Check if the file is empty. If it's empty, create the template.
+        elif os.path.getsize(GRANULAR_LOG_FILE) == 0:
+            logger.debug(f"File {GRANULAR_LOG_FILE} exists but is empty. Creating template...")
+            template: Dict[str, List[Any]] = {
+                "UpdateLog": []
+            }
+            with open(GRANULAR_LOG_FILE, "w") as file:
+                json.dump(template, file)
+
         if log:
             self.update_granular_with_log(log)
             return

--- a/inbm/dispatcher-agent/tests/unit/test_update_logger.py
+++ b/inbm/dispatcher-agent/tests/unit/test_update_logger.py
@@ -197,6 +197,37 @@ class TestUpdateLogger(TestCase):
         assert mock_run.call_count == 2
         self.assertEqual(granular_log, expected_content)
 
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', side_effect=[("install ok installed", "", 0),
+                                                                              ("1:26.3+1-1ubuntu2", "", 0)])
+    @patch('dispatcher.update_logger.detect_os', return_value='Ubuntu')
+    def test_save_granular_log_file_sota_with_empty_granular_file_exist(self, mock_os, mock_run) -> None:
+        self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 3, 1, 50, 55, 935223)
+        self.update_logger.package_list = "emacs"
+        expected_content = {
+                            "UpdateLog": [
+                                    {
+                                        "update_type": "application",
+                                        "package_name": "emacs",
+                                        "update_time": "2024-07-03T01:50:55.935223",
+                                        "action": "install",
+                                        "status": "SUCCESS",
+                                        "version": "1:26.3+1-1ubuntu2"
+                                    }
+                                ]
+                            }
+        # Create an empty GRANULAR_LOG_FILE
+        with open(GRANULAR_LOG_FILE, 'w') as file:
+            pass
+
+        self.update_logger.save_granular_log_file()
+
+        with open(GRANULAR_LOG_FILE, 'r') as f:
+            granular_log = json.load(f)
+
+        assert mock_run.call_count == 2
+        self.assertEqual(granular_log, expected_content)
+
     @patch('dispatcher.update_logger.detect_os', return_value='tiber')
     def test_save_granular_log_file_sota_with_tiberos_and_log(self, mock_os) -> None:
         self.update_logger.ota_type = "sota"


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION



The recent changes in PUA no longer remove the granular log file. Instead, it truncates the file. This causes an error in INBM because the file exists but contains empty data. The PR resolves the issue by checking the content of the file. If the file exists with empty data, it will create the template and continue the package checks.


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Granular log file exists with empty data. |
| Jira ticket | NEXMANAGE-846 |


### CODE MAINTAINABILITY

- [x] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
