### PR TITLE
[NEX-14264] Download file to /opt dir in TiberOS

### DIFF
--- a/inbm-lib/inbm_lib/path_prefixes.py
+++ b/inbm-lib/inbm_lib/path_prefixes.py
@@ -19,6 +19,7 @@ if platform.system() == 'Windows':
     INTEL_MANAGEABILITY_CACHE_PATH_PREFIX = INBM_PATH / 'cache'
     INTEL_MANAGEABILITY_BINARY_SEARCH_PATHS = [
         C_COLON / 'Windows' / 'System32' / 'wbem']  # wmic tool
+    INTEL_MANAGEABILITY_OPT = INBM_PATH / 'opt'
     LOG_PATH = INTEL_MANAGEABILITY_VAR_PATH_PREFIX / 'log'
 else:
     ROOT = Path('/')
@@ -32,4 +33,5 @@ else:
                                                ROOT / 'usr' / 'sbin',
                                                ROOT / 'usr' / 'bin',
                                                ROOT / 'sbin']
+    INTEL_MANAGEABILITY_OPT = ROOT / 'opt'
     LOG_PATH = ROOT / 'var' / 'log'

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## NEXT - YYYY-MM-DD
+### Changed
+ - (NEX-14264) Download file to /opt directory in TiberOS
 
 ## 4.2.6.1 - 2024-10-18
 ### Added

--- a/inbm/dispatcher-agent/dispatcher/sota/constants.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/constants.py
@@ -5,7 +5,7 @@
     SPDX-License-Identifier: Apache-2.0
 """
 
-from inbm_lib.path_prefixes import INTEL_MANAGEABILITY_CACHE_PATH_PREFIX
+from inbm_lib.path_prefixes import INTEL_MANAGEABILITY_CACHE_PATH_PREFIX, INTEL_MANAGEABILITY_OPT
 from inbm_common_lib.utility import get_canonical_representation_of_path
 
 # Mender file path
@@ -32,6 +32,8 @@ PROCEED_WITHOUT_ROLLBACK_DEFAULT = False
 # Device local cache for SOTA
 SOTA_CACHE = str(INTEL_MANAGEABILITY_CACHE_PATH_PREFIX / 'repository-tool' / 'sota')
 
+# Download folder for SOTA in TiberOS
+SOTA_OPT_PATH = str(INTEL_MANAGEABILITY_OPT/ 'sota')
 
 FAILED = "Failed"
 SUCCESS = "Success"

--- a/inbm/dispatcher-agent/dispatcher/sota/os_updater.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/os_updater.py
@@ -18,7 +18,7 @@ from inbm_common_lib.shell_runner import PseudoShellRunner
 from inbm_lib.constants import DOCKER_CHROOT_PREFIX, CHROOT_PREFIX
 
 from .command_list import CommandList
-from .constants import MENDER_FILE_PATH, SOTA_CACHE
+from .constants import MENDER_FILE_PATH, SOTA_OPT_PATH
 from .converter import size_to_bytes
 from .sota_error import SotaError
 from ..common import uri_utilities
@@ -436,7 +436,7 @@ class TiberOSUpdater(OsUpdater):
             parsed_uri = urlparse(self._uri)
             filename = os.path.basename(parsed_uri.path)
             if filename:
-                file_path = os.path.join(SOTA_CACHE, filename)
+                file_path = os.path.join(SOTA_OPT_PATH, filename)
 
         cmds = [update_tool_write_command(self._signature, file_path)]
         return CommandList(cmds).cmd_list

--- a/inbm/dispatcher-agent/fpm-template/etc/apparmor.d/usr.bin.inbm-dispatcher
+++ b/inbm/dispatcher-agent/fpm-template/etc/apparmor.d/usr.bin.inbm-dispatcher
@@ -90,6 +90,7 @@
   /etc/task_list.yaml r,
   /etc/trtl.conf w,
   /opt/afulnx/afulnx_64 rUx,
+  /opt/sota rw,
   /usr/bin/afulnx_64 rUx,
   /proc/1/comm r,
   /proc/device-tree/firmware/bios/** r,

--- a/inbm/dispatcher-agent/tests/unit/sota/test_sota.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_sota.py
@@ -145,7 +145,8 @@ class TestSota(testtools.TestCase):
     @patch("dispatcher.sota.sota.print_execution_summary")
     @patch("dispatcher.sota.snapshot.DebianBasedSnapshot._rollback_and_delete_snap")
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=('200', "", 0))
-    def test_run_pass(self, mock_run, mock_rollback_and_delete_snap, mock_print,
+    @patch("dispatcher.sota.sota.detect_os", return_value='Ubuntu')
+    def test_run_pass(self, mock_os, mock_run, mock_rollback_and_delete_snap, mock_print,
                       mock_detect_os) -> None:
         mock_detect_os.return_value = 'Ubuntu'
         parsed_manifest = {'log_to_file': 'Y', 'sota_cmd': 'update',


### PR DESCRIPTION


<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

There might not be sufficient space in the /var directory to store the new image. It is recommended to download the image to the persistent /opt directory. 

This PR updates the dispatcher to download the file to **/opt/sota** temporarily. 


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
