### PR TITLE
[NEXMANAGE-949] Check the IMAGE_BUILD_DATE instead of VERSION for TiberOS SOTA verification

### DIFF
--- a/inbm-lib/inbm_common_lib/constants.py
+++ b/inbm-lib/inbm_common_lib/constants.py
@@ -51,5 +51,5 @@ AFULNX_64 = 'afulnx_64'
 # Default signature version
 DEFAULT_HASH_ALGORITHM = 384
 
-# Os release path
-OS_RELEASE_PATH = '/etc/os-release'
+# Image id path
+IMAGE_ID_PATH = '/etc/image-id'

--- a/inbm-lib/inbm_common_lib/utility.py
+++ b/inbm-lib/inbm_common_lib/utility.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional, Union, Dict, Tuple
 
-from inbm_common_lib.constants import VALID_MAGIC_FILE_TYPE_PREFIXES, TEMP_EXT_FOLDER, OS_RELEASE_PATH, UNKNOWN
+from inbm_common_lib.constants import VALID_MAGIC_FILE_TYPE_PREFIXES, TEMP_EXT_FOLDER, IMAGE_ID_PATH, UNKNOWN
 from inbm_common_lib.shell_runner import PseudoShellRunner
 
 from .constants import URL_NULL_CHAR
@@ -273,34 +273,34 @@ def validate_file_type(path: list[str]) -> None:
     remove_file_list(extracted_file_list)
 
 
-def get_os_version() -> str:
-    """Get os version from os release file.
+def get_image_build_date() -> str:
+    """Get image build date from image id file.
 
-    @return value of the VERSION
+    @return value of the IMAGE_BUILD_DATE
     """
     try:
-        if os.path.exists(OS_RELEASE_PATH):
-            with open(OS_RELEASE_PATH, 'r') as version_file:
+        if os.path.exists(IMAGE_ID_PATH):
+            with open(IMAGE_ID_PATH, 'r') as version_file:
                 content = version_file.read()
 
-            content_dict = parse_os_release(content)
-            version = content_dict.get("VERSION")
-            if version:
-                return version
-            logger.error(f"VERSION not found in {OS_RELEASE_PATH}.")
+            content_dict = parse_image_id(content)
+            build_date = content_dict.get("IMAGE_BUILD_DATE")
+            if build_date:
+                return build_date
+            logger.error(f"IMAGE_BUILD_DATE not found in {IMAGE_ID_PATH}.")
         else:
-            logger.error(f"{OS_RELEASE_PATH} not exist.")
+            logger.error(f"{IMAGE_ID_PATH} not exist.")
 
         return UNKNOWN
     except OSError as err:
-        raise OSError(f"Error while reading the os version: {err}")
+        raise OSError(f"Error while reading the image build date: {err}")
 
 
-def parse_os_release(file_content: str) -> Dict[str, str]:
+def parse_image_id(file_content: str) -> Dict[str, str]:
     """
-    Parses the content of an os-release file and returns a dictionary of key-value pairs.
+    Parses the content of an image-id file and returns a dictionary of key-value pairs.
 
-    :param file_content: The content of the os-release file as a string.
+    :param file_content: The content of the image id file as a string.
     :return: A dictionary containing key-value pairs from the file.
     """
     result: Dict[str, str] = {}

--- a/inbm-lib/tests/unit/inbm_common_lib/test_utility.py
+++ b/inbm-lib/tests/unit/inbm_common_lib/test_utility.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from inbm_common_lib.exceptions import UrlSecurityException
 from inbm_common_lib.utility import clean_input, get_canonical_representation_of_path, canonicalize_uri, \
-    validate_file_type, remove_file, copy_file, move_file, create_file_with_contents, get_os_version
+    validate_file_type, remove_file, copy_file, move_file, create_file_with_contents, get_image_build_date
 from inbm_common_lib.constants import UNKNOWN
 
 
@@ -112,18 +112,20 @@ class TestUtility(TestCase):
         except IOError as e:
             self.fail(f"Unexpected exception raised during test: {e}")
 
-    @patch('builtins.open', new_callable=mock_open, read_data='VERSION="2.0.20240802.0213"')
-    def test_get_os_version_successfully(self, mock_open: Mock) -> None:
+    @patch('builtins.open', new_callable=mock_open, read_data='IMAGE_BUILD_DATE="20241026100955"')
+    @patch('os.path.exists', return_value=True)
+    def test_get_image_build_date_successfully(self, mock_exist: Mock, mock_open: Mock) -> None:
         try:
-            self.assertEqual(get_os_version(), "2.0.20240802.0213")
+            self.assertEqual(get_image_build_date(), "20241026100955")
         except IOError as e:
             self.fail(f"Unexpected exception raised during test: {e}")
-        mock_open.assert_called_once_with('/etc/os-release', 'r')
+        mock_open.assert_called_once_with('/etc/image-id', 'r')
 
     @patch('builtins.open', new_callable=mock_open, read_data='')
-    def test_get_os_version_with_no_version_found(self, mock_open: Mock) -> None:
+    @patch('os.path.exists', return_value=True)
+    def test_get_image_build_date_with_no_version_found(self, mock_exist: Mock, mock_open: Mock) -> None:
         try:
-            self.assertEqual(get_os_version(), UNKNOWN)
+            self.assertEqual(get_image_build_date(), UNKNOWN)
         except IOError as e:
             self.fail(f"Unexpected exception raised during test: {e}")
-        mock_open.assert_called_once_with('/etc/os-release', 'r')
+        mock_open.assert_called_once_with('/etc/image-id', 'r')

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## NEXT - YYYY-MM-DD
-
+### Changed
+ - (NEXMANAGE-949) Check the IMAGE_BUILD_DATE instead of VERSION for TiberOS SOTA verification
 
 
 ## 4.2.6.2 - 2024-10-25

--- a/inbm/dispatcher-agent/dispatcher/sota/granular_log_handler.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/granular_log_handler.py
@@ -7,7 +7,7 @@ import logging
 import os
 import threading
 
-from inbm_common_lib.utility import get_os_version
+from inbm_common_lib.utility import get_image_build_date
 from inbm_lib.detect_os import detect_os, LinuxDistType
 from inbm_lib.constants import OTA_PENDING, FAIL, OTA_SUCCESS, ROLLBACK, GRANULAR_LOG_FILE
 
@@ -44,7 +44,7 @@ class GranularLogHandler:
                 elif update_logger.detail_status == OTA_SUCCESS or update_logger.detail_status == OTA_PENDING:
                     log = {
                         "StatusDetail.Status": update_logger.detail_status,
-                        "Version": get_os_version()
+                        "Version": get_image_build_date()
                     }
                 # In TiberOS, no package level information needed.
                 update_logger.save_granular_log_file(log=log, check_package=False)

--- a/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/snapshot.py
@@ -12,7 +12,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from inbm_lib.trtl import Trtl
 from typing import Any, Dict, Optional
 from inbm_common_lib.shell_runner import PseudoShellRunner
-from inbm_common_lib.utility import get_os_version
+from inbm_common_lib.utility import get_image_build_date
 from inbm_common_lib.constants import UNKNOWN
 from .constants import MENDER_FILE_PATH
 from .mender_util import read_current_mender_version
@@ -468,9 +468,9 @@ class TiberOSSnapshot(Snapshot):
             "SOTA attempting to create a dispatcher state file before SOTA {}...".
             format(self.sota_cmd))
         try:
-            content = get_os_version()
+            content = get_image_build_date()
             if content == UNKNOWN:
-                raise SotaError("Failed to get os version.")
+                raise SotaError("Failed to get image build date.")
             state: dispatcher_state.DispatcherState
             if dispatcher_state.is_dispatcher_state_file_exists():
                 consumed_state = dispatcher_state.consume_dispatcher_state_file(readonly=True)
@@ -539,7 +539,7 @@ class TiberOSSnapshot(Snapshot):
         state = dispatcher_state.consume_dispatcher_state_file()
         if state is not None and 'tiberos-version' in state:
             logger.debug("got tiberos-version from state: " + str(state['tiberos-version']))
-            version = get_os_version()
+            version = get_image_build_date()
             current_tiberos_version = version
             previous_tiberos_version = state['tiberos-version']
 

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -14,7 +14,7 @@ from typing import Any, List, Optional, Union, Mapping
 
 from dispatcher.sota.granular_log_handler import GranularLogHandler
 from inbm_common_lib.exceptions import UrlSecurityException
-from inbm_common_lib.utility import canonicalize_uri, remove_file, get_os_version
+from inbm_common_lib.utility import canonicalize_uri, remove_file
 from inbm_common_lib.request_message_constants import SOTA_FAILURE
 from inbm_common_lib.constants import REMOTE_SOURCE, LOCAL_SOURCE
 from inbm_lib.validate_package_list import parse_and_validate_package_list

--- a/inbm/dispatcher-agent/fpm-template/etc/apparmor.d/usr.bin.inbm-dispatcher
+++ b/inbm/dispatcher-agent/fpm-template/etc/apparmor.d/usr.bin.inbm-dispatcher
@@ -58,6 +58,7 @@
   /etc/opt/csl/csl-node/csl-manager r,
   /etc/opt/csl/csl-node/long-lived-token r,
   /etc/os-release r,
+  /etc/image-id r,
   /etc/apt/sources.list rw,
   /etc/apt/sources.list.bak rw,
   /etc/apt/sources.list.d/* rw,

--- a/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_granular_log_handler.py
@@ -15,9 +15,9 @@ class TestGranularLogHandler(testtools.TestCase):
     @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
-    @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')
+    @patch('dispatcher.sota.granular_log_handler.get_image_build_date', return_value='20241026100955')
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_os_version, mock_load, mock_dump, mock_exists, mock_truncate) -> None:
+    def test_save_granular_in_tiberos_with_success_log(self, mock_run, mock_get_image_build_date, mock_load, mock_dump, mock_exists, mock_truncate) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = OTA_SUCCESS
 
@@ -28,7 +28,7 @@ class TestGranularLogHandler(testtools.TestCase):
             "UpdateLog": [
                 {
                     "StatusDetail.Status": OTA_SUCCESS,
-                    "Version": '2.0.20240802.0213'
+                    "Version": '20241026100955'
                 }
             ]
         }
@@ -40,9 +40,9 @@ class TestGranularLogHandler(testtools.TestCase):
     @patch('os.path.exists', return_value=False)
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
-    @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')    
+    @patch('dispatcher.sota.granular_log_handler.get_image_build_date', return_value='20241026100955')
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_os_version, mock_load, mock_dump, mock_exists, mock_truncate) -> None:
+    def test_save_granular_in_tiberos_with_pending_log(self, mock_run, mock_get_image_build_date, mock_load, mock_dump, mock_exists, mock_truncate) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = OTA_PENDING
 
@@ -53,7 +53,7 @@ class TestGranularLogHandler(testtools.TestCase):
             "UpdateLog": [
                 {
                     "StatusDetail.Status": OTA_PENDING,
-                    "Version": '2.0.20240802.0213'
+                    "Version": '20241026100955'
                 }
             ]
         }
@@ -112,9 +112,9 @@ class TestGranularLogHandler(testtools.TestCase):
     @patch('os.path.exists', side_effect=[True, False])
     @patch('json.dump')
     @patch('json.load', return_value={"UpdateLog":[]})
-    @patch('dispatcher.sota.granular_log_handler.get_os_version', return_value='2.0.20240802.0213')
+    @patch('dispatcher.sota.granular_log_handler.get_image_build_date', return_value='20241026100955')
     @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("tiber", "", 0))
-    def test_save_granular_in_tiberos_with_truncate_file_being_called(self, mock_run, mock_get_os_version, mock_load, mock_dump, mock_exists) -> None:
+    def test_save_granular_in_tiberos_with_truncate_file_being_called(self, mock_run, mock_get_image_build_date, mock_load, mock_dump, mock_exists) -> None:
         update_logger = UpdateLogger("SOTA", "metadata")
         update_logger.detail_status = OTA_SUCCESS
 
@@ -128,7 +128,7 @@ class TestGranularLogHandler(testtools.TestCase):
             "UpdateLog": [
                 {
                     "StatusDetail.Status": OTA_SUCCESS,
-                    "Version": '2.0.20240802.0213'
+                    "Version": '20241026100955'
                 }
             ]
         }

--- a/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_snapshot.py
@@ -205,9 +205,9 @@ class TestYoctoSnapshot(unittest.TestCase):
 
 class TestTiberOSSnapshot(unittest.TestCase):
     @patch('dispatcher.sota.snapshot.dispatcher_state', autospec=True)
-    @patch('inbm_common_lib.utility.get_os_version', autospec=True)
+    @patch('dispatcher.sota.snapshot.get_image_build_date', autospec=True)
     def test_take_snapshot_succeeds(self, mock_version, mock_dispatcher_state) -> None:
-        mock_version.return_value = "2.0.20240802.0213"
+        mock_version.return_value = "20241026100955"
         mock_dispatcher_state.write_dispatcher_state_to_state_file.return_value = True
 
         dispatcher_broker = Mock()
@@ -220,7 +220,7 @@ class TestTiberOSSnapshot(unittest.TestCase):
         message, = args
         assert "unsuccessful" not in message
 
-    @patch('dispatcher.sota.snapshot.get_os_version', return_value=UNKNOWN)
+    @patch('dispatcher.sota.snapshot.get_image_build_date', return_value=UNKNOWN)
     def test_take_snapshot_unknown_version_error(self, mock_version) -> None:
         dispatcher_broker = Mock()
 
@@ -266,9 +266,9 @@ class TestTiberOSSnapshot(unittest.TestCase):
         assert mock_dispatcher_state.clear_dispatcher_state.call_count == 1
         assert rebooter.reboot.call_count == 1
 
-    @patch('dispatcher.sota.snapshot.get_os_version', return_value='2.0.20240802.0213')
+    @patch('dispatcher.sota.snapshot.get_image_build_date', return_value='20241026100955')
     @patch('dispatcher.common.dispatcher_state.consume_dispatcher_state_file',
-           return_value={'restart_reason': 'sota', 'tiberos-version': '2.0.20240802.0213'})
+           return_value={'restart_reason': 'sota', 'tiberos-version': '20241026100955'})
     def test_update_system_raise_error_when_versions_are_same(self, mock_consume_disp_state, mock_version) -> None:
         tiberos_snapshot = TiberOSSnapshot(Mock(), "command", Mock(), "1", True, True)
         with self.assertRaises(SotaError):


### PR DESCRIPTION


<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

After SOTA system reboot, the VERSION in /etc/os-release remains the same as before.

However, if we check the image build date at /etc/image-id, it's showing the correct image that we want to flash.

Based on the testing, the dispatcher agent should checks the IMAGE_BUILD_DATE instead of VERSION.

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | NEXMANAGE-949 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
