### PR TITLE
[NEXMANAGE-513] Record granular log in download-only mode

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## NEXT - YYYY-MM-DD
+## Next Release
+### Changed
+ - (NEXMANAGE-513) Record the granular log in download-only mode
 
 ## 4.2.7 - 2024-11-8
 ### Changed

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Next Release
 ### Changed
  - (NEXMANAGE-513) Record the granular log in download-only mode
+   
+### Added
+- (NEXMANAGE-826) Update granular log to support architecture independent package
 
 ## 4.2.7 - 2024-11-8
 ### Changed
@@ -14,7 +17,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
  - (NEXMANAGE-950) Add Set Power State Capability to cloudadapter from UDM
- - (NEXMANAGE-826) Update granular log to support architecture independent package
 
 ### Fixed
  - (NEXMANAGE-733) Fixed typo in package_list during conversion from INBS to cloudadapter

--- a/inbm/dispatcher-agent/dispatcher/sota/sota.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/sota.py
@@ -400,18 +400,7 @@ class SOTA:
                 if self._is_ota_no_update_available(cmd_list) and self._package_list == "":
                     # if no package upgrade/install, set the status to OTA_NO_UPDATE and skip saving the granular data.
                     self._update_logger.status = OTA_NO_UPDATE
-
-                # Always save the granular log in TiberOS. In TiberOS, the download-only mode is used to download
-                # the artifacts from the OCI registry. The granular log is enabled in TiberOS with the download-only
-                # mode here to record the successful SOTA with current os version.
-                # TODO: Remove Mariner when confirmed that TiberOS is in use
-                elif detect_os() == LinuxDistType.tiber.name or detect_os() == LinuxDistType.Mariner.name:
-                    self._granular_log_handler.save_granular_log(update_logger=self._update_logger)
-
-                # The download-only mode only downloads the packages without installing them.
-                # Since there is no installation, there will be no changes in the package status or version.
-                # The apt history.log also doesn't record any changes. Therefore we can skip saving granular log.
-                elif self.sota_mode != 'download-only':
+                else:
                     self._granular_log_handler.save_granular_log(update_logger=self._update_logger)
 
 
@@ -426,14 +415,7 @@ class SOTA:
                 # Save the log before reboot
                 self._update_logger.status = FAIL
                 self._update_logger.save_log()
-                # Always save the granular log in TiberOS. In TiberOS, the download-only mode is used to download
-                # the artifacts from the OCI registry. The granular log is enabled in TiberOS with the download-only
-                # mode because we want to record the artifact download failure.
-                # TODO: Remove Mariner when confirmed that TiberOS is in use
-                if detect_os() == LinuxDistType.tiber.name or detect_os() == LinuxDistType.Mariner.name:
-                    self._granular_log_handler.save_granular_log(update_logger=self._update_logger)
-                elif self.sota_mode != 'download-only':
-                    self._granular_log_handler.save_granular_log(update_logger=self._update_logger)
+                self._granular_log_handler.save_granular_log(update_logger=self._update_logger)
                 self._dispatcher_broker.telemetry(SOTA_FAILURE)
                 self._dispatcher_broker.send_result(SOTA_FAILURE)
                 raise SotaError(SOTA_FAILURE)


### PR DESCRIPTION


<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

The dispatcher will record the granular log even though it's download-only mode to capture the package failure.

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | NEXMANAGE-513 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
