### PR TITLE
[NEXMANAGE-1101] Fix history log issue

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## X.X.X - YYYY-MM-DD
  - (NEX-15262) Returns failure reason that matches the format required by MM
 
+### Fixed
+ - (NEXMANAGE-1101) Fix History Log Issue
+
 ## 4.2.8 - 2024-11-29
 ### Changed
  - (NEXMANAGE-513) Record the granular log in download-only mode

--- a/inbm/dispatcher-agent/dispatcher/update_logger.py
+++ b/inbm/dispatcher-agent/dispatcher/update_logger.py
@@ -140,40 +140,47 @@ class UpdateLogger:
                 # Filter parts that contain 'upgrade'
                 upgrade_parts = [part for part in parts if 'upgrade' in part.lower()]
                 if upgrade_parts:
-                    latest_upgrade = upgrade_parts[-1]
-                else:
-                    raise KeyError
-                update_time = get_package_start_date(latest_upgrade)
-                package_dict = extract_package_names_and_versions(latest_upgrade)
+                    upgrade_parts_shadow = upgrade_parts.copy()
+                    # Only look at entries >= SOTA time, removing the old entries
+                    for upgrade_part in upgrade_parts_shadow:
+                        upgrade_time = get_package_start_date(upgrade_part)
+                        if datetime.datetime.strptime(upgrade_time, '%Y-%m-%d  %H:%M:%S') < self._time:
+                            upgrade_parts.remove(upgrade_part)
 
-                # Load current data in granular log file.
-                with open(GRANULAR_LOG_FILE, 'r') as f:
-                    data = json.load(f)
+                # After filtering, if there are entries, save all entries into the granular log.
+                if upgrade_parts:
+                    for upgrade_part in upgrade_parts:
+                        update_time = get_package_start_date(upgrade_part)
+                        package_dict = extract_package_names_and_versions(upgrade_part)
 
-                # Create the package information and store it
-                for package_name, version in package_dict.items():
-                    logger.debug(f"Package: {package_name}, Version: {version}")
+                        # Load current data in granular log file.
+                        with open(GRANULAR_LOG_FILE, 'r') as f:
+                            data = json.load(f)
 
-                    # Get status using dpkg-query
-                    status = check_package_status(package_name)
+                        # Create the package information and store it
+                        for package_name, version in package_dict.items():
+                            logger.debug(f"Package: {package_name}, Version: {version}")
 
-                    package_info = {
-                        "update_type": OS,
-                        "package_name": package_name,
-                        "update_time": update_time,
-                        "action": PACKAGE_UPGRADE,
-                        "status": status,
-                        "version": version
-                    }
-                    # Remove previous entries with the same package_name from the UpdateLog list
-                    data['UpdateLog'] = [log for log in data['UpdateLog'] if
-                                         log['package_name'] != package_info['package_name']]
-                    # Append the new package information to the UpdateLog list
-                    data['UpdateLog'].append(package_info)
+                            # Get status using dpkg-query
+                            status = check_package_status(package_name)
 
-                # Open the file in write mode to save the updated data
-                with open(GRANULAR_LOG_FILE, 'w') as f:
-                    json.dump(data, f, indent=4)
+                            package_info = {
+                                "update_type": OS,
+                                "package_name": package_name,
+                                "update_time": update_time,
+                                "action": PACKAGE_UPGRADE,
+                                "status": status,
+                                "version": version
+                            }
+                            # Remove previous entries with the same package_name from the UpdateLog list
+                            data['UpdateLog'] = [log for log in data['UpdateLog'] if
+                                                 log['package_name'] != package_info['package_name']]
+                            # Append the new package information to the UpdateLog list
+                            data['UpdateLog'].append(package_info)
+
+                        # Open the file in write mode to save the updated data
+                        with open(GRANULAR_LOG_FILE, 'w') as f:
+                            json.dump(data, f, indent=4)
         except (IndexError, KeyError) as e:
             logger.info(f"No upgrade information found in history log. Error: {e}")
 

--- a/inbm/dispatcher-agent/dispatcher/update_logger.py
+++ b/inbm/dispatcher-agent/dispatcher/update_logger.py
@@ -144,7 +144,7 @@ class UpdateLogger:
                     # Only look at entries >= SOTA time, removing the old entries
                     for upgrade_part in upgrade_parts_shadow:
                         upgrade_time = get_package_start_date(upgrade_part)
-                        if datetime.datetime.strptime(upgrade_time, '%Y-%m-%d  %H:%M:%S') < self._time:
+                        if datetime.datetime.fromisoformat(upgrade_time) < self._time:
                             upgrade_parts.remove(upgrade_part)
 
                 # After filtering, if there are entries, save all entries into the granular log.

--- a/inbm/dispatcher-agent/tests/unit/test_update_logger.py
+++ b/inbm/dispatcher-agent/tests/unit/test_update_logger.py
@@ -105,6 +105,91 @@ class TestUpdateLogger(TestCase):
         mock_status.assert_called_once()
         self.assertEqual(granular_log, expected_content)
 
+    @patch('inbm_common_lib.shell_runner.PseudoShellRunner.run', return_value=("install ok installed", "", 0))
+    @patch('dispatcher.update_logger.detect_os', return_value='Ubuntu')
+    def test_save_granular_log_file_sota_upgrade_history_log(self, mock_os, mock_status) -> None:
+        self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 3)
+
+        history_content = """
+        
+        Start-Date: 2024-07-02  06:00:37
+        Commandline: apt install --only-upgrade -y inbc-program trtl inbm-cloudadapter-agent inbm-dispatcher-agent inbm-configuration-agent inbm-telemetry-agent inbm-diagnostic-agent mqtt tpm-provision
+        Requested-By: platform-update-agent (997)
+        Upgrade: inbm-diagnostic-agent:amd64 (4.2.6.1-1, 4.2.8-1), inbm-configuration-agent:amd64 (4.2.6.1-1, 4.2.8-1), inbm-cloudadapter-agent:amd64 (4.2.6.1-1, 4.2.8-1), mqtt:amd64 (4.2.6.1-1, 4.2.8-1), inbc-pro>
+        End-Date: 2024-07-02  06:00:51
+
+        Start-Date: 2024-07-03  19:28:53
+        Commandline: /bin/apt-get -yq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --with-new-pkgs upgrade
+        Upgrade: terraform:amd64 (1.9.0-1, 1.9.1-1)
+        End-Date: 2024-07-03  19:28:53
+
+        Start-Date: 2024-07-04  03:53:31
+        Commandline: apt install platform-update-agent
+        Upgrade: platform-update-agent:amd64 (1.2.11, 1.2.18)
+        End-Date: 2024-07-04  03:53:32
+
+        """
+
+        expected_content = {
+                            "UpdateLog": [
+                                    {
+                                        "update_type": "os",
+                                        "package_name": "terraform:amd64",
+                                        "update_time": "2024-07-03T19:28:53",
+                                        "action": "upgrade",
+                                        "status": "SUCCESS",
+                                        "version": "1.9.0-1, 1.9.1-1"
+                                    },
+                                    {
+                                        "update_type": "os",
+                                        "package_name": "platform-update-agent:amd64",
+                                        "update_time": "2024-07-04T03:53:31",
+                                        "action": "upgrade",
+                                        "status": "SUCCESS",
+                                        "version": "1.2.11, 1.2.18"
+                                    }
+                                ]
+                            }
+
+        with open(SYSTEM_HISTORY_LOG_FILE, "w") as file:
+            file.write(history_content)
+
+        self.update_logger.save_granular_log_file()
+
+        with open(GRANULAR_LOG_FILE, 'r') as f:
+            granular_log = json.load(f)
+
+        assert mock_status.call_count == 2
+        self.assertEqual(granular_log, expected_content)
+
+    @patch('dispatcher.update_logger.detect_os', return_value='Ubuntu')
+    def test_save_granular_log_file_sota_upgrade_history_log_start_time_before_sota_time(self, mock_os) -> None:
+        self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 3)
+
+        history_content = """
+        Start-Date: 2024-07-02  19:28:53
+        Commandline: /bin/apt-get -yq -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --with-new-pkgs upgrade
+        Upgrade: terraform:amd64 (1.9.0-1, 1.9.1-1)
+        End-Date: 2024-07-02  19:28:53
+        """
+
+        expected_content: dict = {
+                            "UpdateLog": [
+                                ]
+                            }
+
+        with open(SYSTEM_HISTORY_LOG_FILE, "w") as file:
+            file.write(history_content)
+
+        self.update_logger.save_granular_log_file()
+
+        with open(GRANULAR_LOG_FILE, 'r') as f:
+            granular_log = json.load(f)
+
+        self.assertEqual(granular_log, expected_content)
+
     def test_save_granular_log_file_sota_without_package_list_without_upgrade_but_with_upgrade_keyword_in_text(self) -> None:
         self.update_logger.ota_type = "sota"
         self.update_logger._time = datetime.datetime(2024, 7, 2)

--- a/inbm/dispatcher-agent/tests/unit/test_update_logger.py
+++ b/inbm/dispatcher-agent/tests/unit/test_update_logger.py
@@ -72,6 +72,7 @@ class TestUpdateLogger(TestCase):
     @patch('dispatcher.update_logger.detect_os', return_value='Ubuntu')
     def test_save_granular_log_file_sota_without_package_list(self, mock_os, mock_status) -> None:
         self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 2)
 
         history_content = """
         Start-Date: 2024-07-03  19:28:53
@@ -106,6 +107,7 @@ class TestUpdateLogger(TestCase):
 
     def test_save_granular_log_file_sota_without_package_list_without_upgrade_but_with_upgrade_keyword_in_text(self) -> None:
         self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 2)
 
         history_content = """
         Start-Date: 2024-08-06  06:26:14
@@ -141,6 +143,7 @@ class TestUpdateLogger(TestCase):
 
     def test_save_granular_log_file_sota_without_package_list_without_update_keyword(self) -> None:
         self.update_logger.ota_type = "sota"
+        self.update_logger._time = datetime.datetime(2024, 7, 2)
 
         history_content = """
         Start-Date: 2024-08-06  07:45:30


### PR DESCRIPTION

<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

INBM checks the start time of the history log entries. If the log entries are within the OTA timeframe, it will proceed to parse the log and save the package-level information into the granular log file.

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | When INBM looks at the history.log, it always picks the last upgrade log entries. To capture all the upgrade information, INBM needs a logic to parse all the upgrade data within the desired timeframe. |
| Jira ticket | NEXMANAGE-1101 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
