### PR TITLE
[NEXMANAGE-1113] Provide hash to UT

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
  - (NEXMANAGE-1101) Fix History Log Issue
 
+### Added
+ - (NEXMANAGE-1113) Provide hash to UT
+
 ## 4.2.8 - 2024-11-29
 ### Changed
  - (NEXMANAGE-513) Record the granular log in download-only mode

--- a/inbm/dispatcher-agent/dispatcher/sota/update_tool_util.py
+++ b/inbm/dispatcher-agent/dispatcher/sota/update_tool_util.py
@@ -36,7 +36,7 @@ def update_tool_write_command(signature: Optional[str] = None, file_path: Option
         else:
             raise SotaError("Signature checks failed.")
 
-    return str(TIBER_UPDATE_TOOL_PATH + " -w" + " -u " + file_path)
+    return str(TIBER_UPDATE_TOOL_PATH + " -w" + " -u " + file_path + " -s " + signature)
 
 
 def update_tool_commit_command() -> int:

--- a/inbm/dispatcher-agent/tests/unit/sota/test_update_tool_util.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_update_tool_util.py
@@ -26,7 +26,7 @@ class TestDownloader(unittest.TestCase):
                     sha256_hash.update(chunk)
             checksum = sha256_hash.hexdigest()
 
-            expected_cmd = f'{TIBER_UPDATE_TOOL_PATH} -w -u {os.path.join(repo.get_repo_path(), "test")}'
+            expected_cmd = f'{TIBER_UPDATE_TOOL_PATH} -w -u {os.path.join(repo.get_repo_path(), "test")} -s {checksum}'
             cmd = update_tool_write_command(signature=checksum, file_path=file_path)
             self.assertEqual(cmd, expected_cmd)
         finally:


### PR DESCRIPTION


<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

UT needs hash to verify the image before writing it to the partition to combat the TOCTOU vulnerability. This PR updates INBM to invoke the tool with /usr/bin/os-update-tool.sh -w -u <path> -s <#sha>.


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
