### PR TITLE
[NEXMANAGE-1121] Remove mqtt-ca group from /var/cache/manageability/repository-tool directory

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Next Release - YYYY-MM-DD
+### Changed
+ - (NEXMANAGE-1121) Remove mqtt-ca group from /var/cache/manageability directory
+
 ## 4.2.8.1 - 2024-12-17
  - (NEX-15262) Returns failure reason that matches the format required by MM
  - (NEXMANAGE-1102) XML schema validator run into exception when field tag is not complete in manifest

--- a/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-keys-generated
+++ b/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-keys-generated
@@ -94,7 +94,7 @@ fix_permissions() {
     fi
 
     # Set up temp file permissions
-    chown -R root.mqtt-ca /var/cache/manageability
+    chown -R root.root /var/cache/manageability
     chmod -R o-rwx /var/cache/manageability
     chmod -R ug+rw /var/cache/manageability
     find /var/cache/manageability -type d -exec chmod g+s {} \;  # Make sure new files have correct group ownership

--- a/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-keys-generated
+++ b/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-keys-generated
@@ -94,10 +94,16 @@ fix_permissions() {
     fi
 
     # Set up temp file permissions
-    chown -R root.root /var/cache/manageability
+    chown -R root.mqtt-ca /var/cache/manageability
     chmod -R o-rwx /var/cache/manageability
     chmod -R ug+rw /var/cache/manageability
     find /var/cache/manageability -type d -exec chmod g+s {} \;  # Make sure new files have correct group ownership
+
+    # Set up repository-tool directory permissions
+    mkdir -p /var/cache/manageability/repository-tool
+    chown -R root.root /var/cache/manageability/repository-tool
+    chmod -R o-rwx /var/cache/manageability/repository-tool
+    chmod -R ug+rw /var/cache/manageability/repository-tool
 
     # Make sure 'docker' group exists for diagnostic agent's .service file
     if [ "$ID" != "tiber" ]; then


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

Due to the security concern, the /var/cache/manageability/repository-tool  directory can only be accessed by root.


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | - |
| Jira ticket | NEXMANAGE-1121 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
