### PR TITLE
[NEXMANAGE-1194] provision-tc/mqtt service should handle UDM case

### DIFF
--- a/docs/In-Band Manageability User Guide - INBS.md
+++ b/docs/In-Band Manageability User Guide - INBS.md
@@ -45,3 +45,37 @@ To disable TLS (for example, for testing), set "tls_enabled" to false. tls_cert_
 - **tls_enabled**: Boolean value to enable or disable TLS. Set to `true` to enable TLS.
 - **tls_cert_path**: (ignored if TLS is disabled) The system path to the TLS certificate used for establishing a secure connection to the INBS server. It is recommended that the path be under `/etc/intel-manageability/public/` to ensure the certificate is accessible to the cloudadapter agent.
 - **token_path**: (ignored if TLS is disabled) Path to the file containing the confidential authentication token used to verify the device with the INBS server. It is recommended that the path be under `/etc/intel-manageability/secret/` to ensure the token is secure.
+
+### UDM Bootstrap Mode
+
+The user can also set up `adapter.cfg` in "UDM Bootstrap" mode, like this:
+
+```
+{
+  "cloud": "inbs",
+  "config": {
+    "onboarding_json_file": "/path/to/onboarding.json"
+  }
+}
+```
+
+The file `onboarding.json` is provided by UDM to give agents on the edge
+node a unified view of the device's credentials and addresses to service
+endpoints.
+
+Example:
+
+```
+{ 
+"jwt_token": "sample_jwt_token", 
+"refresh_token": "sample_refresh_token", 
+"node_id": "sample_node_id", 
+"services": [ 
+    { 
+      "type": "INBS", 
+      "host": "example.com", 
+      "port": "8080" 
+    } 
+] 
+} 
+```

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## X.X.X - YYYY-MM-DD
 ### Changed
 - (NEXMANAGE-956) Improve failure reason from TC that is logged in Mjunct DB for FOTA
+- (NEXMANAGE-1194) provision-tc/mqtt services will now handle UDM 
 
 ## 4.2.8.2 - 2024-12-18
 ### Changed

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
@@ -67,7 +67,6 @@ class InbsAdapter(Adapter):
             except ValueError:
                 raise AdapterConfigureError("Port must be an integer")
 
-            # Get the token (assuming jwt_token is used as token)
             token = onboarding_data.get("jwt_token")
             if not token:
                 raise AdapterConfigureError("Missing jwt_token in onboarding.json")
@@ -122,7 +121,7 @@ class InbsAdapter(Adapter):
             hostname=hostname,
             port=port,
             node_id=node_id,
-            token=token if tls_enabled else None,
+            token=token,
             tls_enabled=tls_enabled,
             tls_cert=tls_cert if tls_enabled else None
         )

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
@@ -73,7 +73,7 @@ class InbsAdapter(Adapter):
                 raise AdapterConfigureError("Missing jwt_token in onboarding.json")
 
             tls_cert = None  # TLS cert always comes from system
-            tls_enabled = True  # TLS is always enabled in this mode
+            tls_enabled = False  # Today, INBS does _not_ support TLS in this mode, but later we will enable it
 
         else:
             # Existing mode

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/adapters/inbs_adapter.py
@@ -12,9 +12,10 @@ from ...exceptions import AdapterConfigureError
 from ...cloud.client.inbs_cloud_client import InbsCloudClient
 from ..client.cloud_client import CloudClient
 from .adapter import Adapter
-from typing import Callable
+from typing import Callable, Optional
 import logging
 import os
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -29,52 +30,102 @@ class InbsAdapter(Adapter):
         @param configs: schema conforming JSON config data
         @exception AdapterConfigureError: If configuration fails
         """
-        hostname = configs.get("hostname")
-        if not hostname:
-            raise AdapterConfigureError("Missing hostname")
+        onboarding_json_file = configs.get("onboarding_json_file")
+        if onboarding_json_file:
+            # New mode using onboarding_json_file
+            if not os.path.exists(onboarding_json_file):
+                raise AdapterConfigureError(f"Onboarding JSON file '{onboarding_json_file}' does not exist")
 
-        port = configs.get("port")
-        if not port:
-            raise AdapterConfigureError("Missing port")
-        try:
-            port_int = int(port)
-            if not (0 < port_int < 65536):
-                raise AdapterConfigureError("Port number must be between 1 and 65535")
-        except ValueError:
-            raise AdapterConfigureError("Port must be an integer")
+            with open(onboarding_json_file, 'r') as f:
+                onboarding_data = json.load(f)
 
-        node_id = configs.get("node_id")
-        if not node_id:
-            raise AdapterConfigureError("Missing node_id")
+            node_id = onboarding_data.get("node_id")
+            if not node_id:
+                raise AdapterConfigureError("Missing node_id in onboarding.json")
 
-        tls_enabled = configs.get("tls_enabled", True)
-        if tls_enabled:
-            tls_cert_path = configs.get("tls_cert_path")
-            if not tls_cert_path or not os.path.exists(tls_cert_path):
-                raise AdapterConfigureError(
-                    "TLS is enabled but missing or incorrect certificate file path")
-            with open(tls_cert_path, 'rb') as f:
-                tls_cert = f.read()
+            services = onboarding_data.get("services", [])
+            inbs_service = None
+            for service in services:
+                if service.get("type") == "INBS":
+                    inbs_service = service
+                    break
 
-            token: str | None = None
-            token_path: str = configs.get("token_path")  # type: ignore
-            if (not token_path or not os.path.exists(token_path)):
-                raise AdapterConfigureError(
-                    "TLS is enabled but missing or incorrect token file path")
-            with open(token_path, 'r') as f:
-                token = f.read().strip()
+            if not inbs_service:
+                raise AdapterConfigureError("No INBS service found in onboarding.json")
+
+            hostname = inbs_service.get("host")
+            if not hostname:
+                raise AdapterConfigureError("Missing host in INBS service from onboarding.json")
+
+            port = inbs_service.get("port")
+            if not port:
+                raise AdapterConfigureError("Missing port in INBS service from onboarding.json")
+            try:
+                port_int = int(port)
+                if not (0 < port_int < 65536):
+                    raise AdapterConfigureError("Port number must be between 1 and 65535")
+            except ValueError:
+                raise AdapterConfigureError("Port must be an integer")
+
+            # Get the token (assuming jwt_token is used as token)
+            token = onboarding_data.get("jwt_token")
+            if not token:
+                raise AdapterConfigureError("Missing jwt_token in onboarding.json")
+
+            tls_cert = None  # TLS cert always comes from system
+            tls_enabled = True  # TLS is always enabled in this mode
+
         else:
-            if configs.get("token_path"):
-                raise AdapterConfigureError("Token path provided but TLS is not enabled")
-            if configs.get("tls_cert_path"):
-                raise AdapterConfigureError("TLS cert path provided but TLS is not enabled")
+            # Existing mode
+            hostname = configs.get("hostname")
+            if not hostname:
+                raise AdapterConfigureError("Missing hostname")
 
-        self._client = InbsCloudClient(hostname=hostname,
-                                       port=port,
-                                       node_id=node_id,
-                                       token=token if tls_enabled else None,
-                                       tls_enabled=tls_enabled,
-                                       tls_cert=tls_cert if tls_enabled else None)
+            port = configs.get("port")
+            if not port:
+                raise AdapterConfigureError("Missing port")
+            try:
+                port_int = int(port)
+                if not (0 < port_int < 65536):
+                    raise AdapterConfigureError("Port number must be between 1 and 65535")
+            except ValueError:
+                raise AdapterConfigureError("Port must be an integer")
+
+            node_id = configs.get("node_id")
+            if not node_id:
+                raise AdapterConfigureError("Missing node_id")
+
+            tls_enabled = configs.get("tls_enabled", True)
+            tls_cert = None
+            token = None
+
+            if tls_enabled:
+                tls_cert_path = configs.get("tls_cert_path")
+                if not tls_cert_path or not os.path.exists(tls_cert_path):
+                    raise AdapterConfigureError("TLS is enabled but missing or incorrect certificate file path")
+                with open(tls_cert_path, 'rb') as f:
+                    tls_cert = f.read()
+
+                token_path = configs.get("token_path")
+                if not token_path or not os.path.exists(token_path):
+                    raise AdapterConfigureError("TLS is enabled but missing or incorrect token file path")
+                with open(token_path, 'r') as f:
+                    token = f.read().strip()
+            else:
+                if configs.get("token_path"):
+                    raise AdapterConfigureError("Token path provided but TLS is not enabled")
+                if configs.get("tls_cert_path"):
+                    raise AdapterConfigureError("TLS cert path provided but TLS is not enabled")
+
+        # Initialize the client with the gathered parameters
+        self._client = InbsCloudClient(
+            hostname=hostname,
+            port=port,
+            node_id=node_id,
+            token=token if tls_enabled else None,
+            tls_enabled=tls_enabled,
+            tls_cert=tls_cert if tls_enabled else None
+        )
         return self._client
 
     def bind_callback(self, name: str, callback: Callable) -> None:

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/client/inbs_cloud_client.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/client/inbs_cloud_client.py
@@ -69,10 +69,7 @@ class InbsCloudClient(CloudClient):
                 raise AuthenticationError("Token is required when TLS is enabled.")
             else:
                 self._metadata.append(("token", token))
-            if tls_cert is None:
-                raise AuthenticationError(
-                    "TLS certificate path is required when TLS is enabled."
-                )
+            # if tls_cert is None, this is OK; implied that we have it installed system wide
         self._stop_event = threading.Event()
 
         self._grpc_channel: grpc.Channel | None = None # this will get set after connect is called
@@ -344,7 +341,10 @@ class InbsCloudClient(CloudClient):
         if self._tls_enabled:
             # Create a secure channel with SSL credentials
             logger.debug("Setting up connection to INBS cloud with TLS enabled")
-            credentials = grpc.ssl_channel_credentials(root_certificates=self._tls_cert)
+            if self._tls_cert is None:  # assume cert is installed system wide
+                credentials = grpc.ssl_channel_credentials()
+            else:    
+                credentials = grpc.ssl_channel_credentials(root_certificates=self._tls_cert)
             self.channel = grpc.secure_channel(
                 f"{self._grpc_hostname}:{self._grpc_port}", credentials
             )

--- a/inbm/cloudadapter-agent/fpm-template/usr/bin/provision-tc
+++ b/inbm/cloudadapter-agent/fpm-template/usr/bin/provision-tc
@@ -18,7 +18,9 @@ set -eo pipefail
 ### The main provisioning function
 function provision {
   check_requirements
-  /usr/bin/mqtt-detect-tpm
+  if [[ "$UDM_MODE" == "false" ]]; then
+    /usr/bin/mqtt-detect-tpm
+  fi
   get_proxies
   if [[ "x$SKIP_DOCKER_CONFIGURATION" == "x" ]]; then
     configure_docker
@@ -32,8 +34,17 @@ function provision {
   fi
   echo "$LOCAL_MQTT_PORT" >/etc/intel-manageability/local-mqtt-port.txt
   enable_mqtt
-  if [[ "x$NO_CLOUD" == "x" ]]; then
-    configure_cloud
+  if [[ "$UDM_MODE" == "false" ]]; then
+    if [[ "$NO_CLOUD" == "" ]]; then
+      configure_cloud
+    fi
+    if ! [[ -v UCC_MODE ]]; then
+      if [[ "$NO_OTA_CERT" == "" ]]; then
+        inb-provision-ota-cert
+      fi
+    fi
+  else
+    configure_cloud_udm_mode
   fi
   if ! [[ -v UCC_MODE ]]; then
     if [[ "x$NO_OTA_CERT" == "x" ]]; then
@@ -284,10 +295,44 @@ function get_file_input {
   done
 }
 
+function configure_cloud_udm_mode {
+  echo "Configuring cloud for UDM_MODE..."
+  local ONBOARDING_JSON="/mnt/udm-luks/onboarding.json"
+  local ADAPTER_CFG_DIR="/etc/intel-manageability/secret/cloudadapter-agent/"
+  local ADAPTER_CFG_FILE="$ADAPTER_CFG_DIR/adapter.cfg"
+
+  if [[ ! -f "$ONBOARDING_JSON" ]]; then
+    echo "Error: Onboarding file $ONBOARDING_JSON does not exist."
+    exit 1
+  fi
+
+  mkdir -p "$ADAPTER_CFG_DIR"
+
+  # Create adapter.cfg with onboarding_json_file reference
+  cat << EOF > "$ADAPTER_CFG_FILE"
+{
+  "cloud": "inbs",
+  "config": {
+    "onboarding_json_file": "$ONBOARDING_JSON"
+  }
+}
+EOF
+
+  chgrp -R cloudadapter-agent "$ADAPTER_CFG_DIR"
+  chmod 640 "$ADAPTER_CFG_FILE"
+}
+
 if grep -q "TRUE" /etc/intel-manageability/public/ucc_flag ; then
     echo "UCC mode."
     UCC_MODE=true
 fi
+
+if [[ "$UDM_MODE" == "true" ]]; then
+    echo "UDM mode."
+else
+    UDM_MODE=false
+fi
+
 
 provision
 

--- a/inbm/cloudadapter-agent/tests/unit/cloud/adapters/test_inbs_adapter.py
+++ b/inbm/cloudadapter-agent/tests/unit/cloud/adapters/test_inbs_adapter.py
@@ -3,7 +3,9 @@ Unit tests for the InbsAdapter class
 """
 
 import unittest
-from mock import patch, mock
+from unittest import mock
+from unittest.mock import patch, mock_open
+import json
 from cloudadapter.cloud.adapters.inbs_adapter import InbsAdapter
 from cloudadapter.exceptions import AdapterConfigureError
 
@@ -12,16 +14,45 @@ class TestInbsAdapter(unittest.TestCase):
 
     def setUp(self) -> None:
         # Define a side effect function that returns different data based on the file name
-        def read_file_side_effect(*args, **kwargs):
-            if args[0] == '/path/to/valid_token.txt':
-                return mock.mock_open(read_data='token_data').return_value
-            elif args[0] == '/path/to/valid_cert.pem':
-                return mock.mock_open(read_data='cert_data').return_value
+        def read_file_side_effect(file, mode='r', *args, **kwargs):
+            if file == '/path/to/valid_token.txt':
+                mock_file = mock.mock_open(read_data='token_data').return_value
+                mock_file.read.return_value = 'token_data'
+                return mock_file
+            elif file == '/path/to/valid_cert.pem':
+                mock_file = mock.mock_open(read_data='cert_data').return_value
+                mock_file.read.return_value = 'cert_data'
+                return mock_file
+            elif file == '/mnt/udm-luks/onboarding.json':
+                onboarding_content = json.dumps({
+                    "jwt_token": "sample_jwt_token",
+                    "refresh_token": "sample_refresh_token",
+                    "node_id": "sample_node_id",
+                    "services": [
+                        {
+                            "type": "INBS",
+                            "host": "example.com",
+                            "port": "8080"
+                        }
+                    ]
+                })
+                mock_file = mock.mock_open(read_data=onboarding_content).return_value
+                mock_file.read.return_value = onboarding_content
+                return mock_file
             else:
+                # Default empty file
                 return mock.mock_open(read_data='').return_value
 
-        self.patcher_open = patch('builtins.open', side_effect=read_file_side_effect)
+        self.patcher_open = patch('builtins.open', new=mock_open())
         self.mock_open = self.patcher_open.start()
+        self.mock_open.side_effect = read_file_side_effect
+
+        self.patcher_exists = patch('os.path.exists', side_effect=lambda x: {
+            '/path/to/valid_token.txt': True,
+            '/path/to/valid_cert.pem': True,
+            '/mnt/udm-luks/onboarding.json': True,
+        }.get(x, False))
+        self.mock_exists = self.patcher_exists.start()
 
         self.base_config = {
             "hostname": "localhost",
@@ -61,68 +92,216 @@ class TestInbsAdapter(unittest.TestCase):
         self.config_tls_unspecified = {
             **self.base_config,
         }
+        self.config_with_onboarding = {
+            "cloud": "inbs",
+            "config": {
+                "onboarding_json_file": "/mnt/udm-luks/onboarding.json"
+            }
+        }
 
     def tearDown(self):
         self.patcher_open.stop()
+        self.patcher_exists.stop()
 
+    # Existing Tests
     def test_configure_succeeds_with_valid_token_and_tls(self):
-
         # Mock the os.path.exists to always return True (e.g., both token and TLS path exist)
-        with patch('os.path.exists', return_value=True):
-            inbs_adapter = InbsAdapter(self.config_with_tls)
-            self.mock_open.assert_has_calls([mock.call('/path/to/valid_token.txt', 'r'),
-                                             mock.call('/path/to/valid_cert.pem', 'rb')],
-                                            any_order=True)
+        inbs_adapter = InbsAdapter(self.config_with_tls)
+        inbs_adapter.configure(self.config_with_tls)
+        self.mock_open.assert_any_call('/path/to/valid_token.txt', 'r')
+        self.mock_open.assert_any_call('/path/to/valid_cert.pem', 'rb')
 
     def test_configure_fails_with_invalid_port(self):
         # Ensure the configuration fails when the port is not an integer
+        invalid_config = {**self.base_config, "port": "invalid_port"}
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter({**self.base_config, "port": "invalid_port"})
+            inbs_adapter = InbsAdapter(invalid_config)
+            inbs_adapter.configure(invalid_config)
 
     def test_configure_fails_with_port_out_of_range(self):
         # Ensure the configuration fails when the port is out of range
+        invalid_config = {**self.base_config, "port": "65536"}
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter({**self.base_config, "port": "65536"})
+            inbs_adapter = InbsAdapter(invalid_config)
+            inbs_adapter.configure(invalid_config)
 
     def test_configure_succeeds_with_valid_token_and_no_tls(self):
         # Test configuration without TLS but with a valid token path (token will be ignored)
-        with patch('os.path.exists', return_value=True):
-            inbs_adapter = InbsAdapter(self.config_without_tls)
-            self.mock_open.assert_not_called()
-
-    def test_configure_fails_if_token_given_with_no_tls(self):
-        # Ensure the configuration fails if token is given but TLS is not enabled
-        with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter(self.config_with_token_path_no_tls)
+        adapter = InbsAdapter(self.config_without_tls)
+        client = adapter.configure(self.config_without_tls)
+        self.mock_open.assert_not_called()
 
     def test_configure_fails_if_no_tls_options(self):
         # Ensure TLS has to be explicitly disabled to be turned off
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter(self.config_tls_unspecified)
+            adapter = InbsAdapter(self.config_tls_unspecified)
+            adapter.configure(self.config_tls_unspecified)
 
     def test_configure_fails_if_certificate_given_with_no_tls(self):
         # Ensure the configuration fails if cert is given but TLS is not enabled
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter(self.config_with_tls_cert_path_no_tls)
+            adapter = InbsAdapter(self.config_with_tls_cert_path_no_tls)
+            adapter.configure(self.config_with_tls_cert_path_no_tls)
 
     def test_configure_fails_with_missing_certificate_for_tls(self):
         # Ensure the configuration fails when the TLS cert file does not exist
         with patch('os.path.exists', side_effect=lambda x: x != '/path/to/valid_cert.pem'):
             with self.assertRaises(AdapterConfigureError):
-                inbs_adapter = InbsAdapter(self.config_with_tls)
+                adapter = InbsAdapter(self.config_with_tls)
+                adapter.configure(self.config_with_tls)
 
     def test_configure_fails_with_missing_token_file(self):
         # Ensure the configuration fails when the token file does not exist
         with patch('os.path.exists', side_effect=lambda x: x != '/path/to/valid_token.txt'):
             with self.assertRaises(AdapterConfigureError):
-                inbs_adapter = InbsAdapter(self.config_with_tls)
+                adapter = InbsAdapter(self.config_with_tls)
+                adapter.configure(self.config_with_tls)
 
     def test_configure_fails_with_missing_token_for_tls(self):
         # Ensure the configuration fails if TLS is enabled but token is not given
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter(self.config_with_tls_no_token)
+            adapter = InbsAdapter(self.config_with_tls_no_token)
+            adapter.configure(self.config_with_tls_no_token)
 
     def test_configure_fails_with_missing_cert_for_tls(self):
         # Ensure the configuration fails if TLS is enabled but cert is not given
         with self.assertRaises(AdapterConfigureError):
-            inbs_adapter = InbsAdapter(self.config_with_tls_no_cert)
+            adapter = InbsAdapter(self.config_with_tls_no_cert)
+            adapter.configure(self.config_with_tls_no_cert)
+
+    def test_configure_succeeds_with_onboarding_json_file(self):
+        # Test configuration using onboarding_json_file
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "INBS",
+                    "host": "example.com",
+                    "port": "8080"
+                }
+            ]
+        }):
+            adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+            client = adapter.configure(self.config_with_onboarding.get('config', {}))
+            self.mock_open.assert_any_call('/mnt/udm-luks/onboarding.json', 'r')
+            self.assertTrue(client._tls_enabled)
+            self.assertEqual(client._grpc_hostname, "example.com")
+            self.assertEqual(client._grpc_port, "8080")
+            self.assertEqual(client._client_id, "sample_node_id")
+            self.assertEqual(client._token, "sample_jwt_token")
+    
+    def test_configure_fails_with_onboarding_json_file_and_bad_port(self):
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "INBS",
+                    "host": "example.com",
+                    "port": "123456789"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                client = adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_missing_onboarding_json_file(self):
+        # Ensure the configuration fails when the onboarding_json_file does not exist
+        with patch('os.path.exists', side_effect=lambda x: False):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_missing_node_id_in_onboarding(self):
+        # Ensure the configuration fails when node_id is missing in onboarding.json
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "services": [
+                {
+                    "type": "INBS",
+                    "host": "example.com",
+                    "port": "8080"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_no_inbs_service_in_onboarding(self):
+        # Ensure the configuration fails when no INBS service is found in onboarding.json
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "OTHER_SERVICE",
+                    "host": "example.com",
+                    "port": "8080"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_missing_host_in_inbs_service(self):
+        # Ensure the configuration fails when INBS service is missing host
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "INBS",
+                    "port": "8080"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_missing_port_in_inbs_service(self):
+        # Ensure the configuration fails when INBS service is missing port
+        with patch('json.load', return_value={
+            "jwt_token": "sample_jwt_token",
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "INBS",
+                    "host": "example.com"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+    def test_configure_fails_with_missing_jwt_token_in_onboarding(self):
+        # Ensure the configuration fails when jwt_token is missing in onboarding.json
+        with patch('json.load', return_value={
+            "refresh_token": "sample_refresh_token",
+            "node_id": "sample_node_id",
+            "services": [
+                {
+                    "type": "INBS",
+                    "host": "example.com",
+                    "port": "8080"
+                }
+            ]
+        }):
+            with self.assertRaises(AdapterConfigureError):
+                adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
+                adapter.configure(self.config_with_onboarding.get('config', {}))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/inbm/cloudadapter-agent/tests/unit/cloud/adapters/test_inbs_adapter.py
+++ b/inbm/cloudadapter-agent/tests/unit/cloud/adapters/test_inbs_adapter.py
@@ -186,7 +186,7 @@ class TestInbsAdapter(unittest.TestCase):
             adapter = InbsAdapter(self.config_with_onboarding.get('config', {}))
             client = adapter.configure(self.config_with_onboarding.get('config', {}))
             self.mock_open.assert_any_call('/mnt/udm-luks/onboarding.json', 'r')
-            self.assertTrue(client._tls_enabled)
+            self.assertFalse(client._tls_enabled)
             self.assertEqual(client._grpc_hostname, "example.com")
             self.assertEqual(client._grpc_port, "8080")
             self.assertEqual(client._client_id, "sample_node_id")

--- a/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-secret-mounted
+++ b/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-secret-mounted
@@ -6,6 +6,26 @@ TC_PUBLIC="/etc/intel-manageability/public"
 TC_SECRET_IMG_DIR="/var/intel-manageability"
 TC_SECRET_IMG="$TC_SECRET_IMG_DIR/secret.img"
 
+# Check if /mnt/udm-luks is mounted
+if mountpoint -q "/mnt/udm-luks" ; then
+    echo "/mnt/udm-luks is mounted. Using bind mount instead of TPM/LUKS."
+
+    # Create /mnt/udm-luks/inbm if it doesn't exist
+    mkdir -p /mnt/udm-luks/inbm
+
+    # Ensure the target directory exists
+    mkdir -p "$TC_SECRET"
+
+    # Perform bind mount
+    mount --bind /mnt/udm-luks/inbm "$TC_SECRET"
+
+    # Ensure public directory exists
+    mkdir -p "$TC_PUBLIC"
+
+    # Exit the script since we've completed the necessary steps for UDM mode
+    exit 0
+fi
+
 safe_mode() {
     set -ex
     mkdir -p "$TC_SECRET"

--- a/inbm/tpm2-simulator/Dockerfile
+++ b/inbm/tpm2-simulator/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update &&\
         sudo &&  \
     apt-get clean
 
+RUN gem install rchardet -v 1.8.0
 RUN gem install public_suffix -v 5.1.1
 RUN gem install dotenv -v 2.8.1
 RUN gem install --no-document fpm -v 1.14.0


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

Implement UDM mode in provision-tc to enable INBS cloud setup using onboarding.json. Add support for reading INBS information from /mnt/udm-luks/onboarding.json, creating adapter.cfg with correct INBS endpoint and TLS configuration. Modify mqtt service to detect /mnt/udm-luks and create a bind mount to /etc/intel-manageability/secret instead of mounting a LUKS volume. Update provision-tc to run without user interaction in UDM mode, skipping TPM provisioning and Docker configuration.


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause |  |
| Jira ticket | NEXMANAGE-1194 |


### CODE MAINTAINABILITY

- [x] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [x] Run `go fmt` or `format-python.sh` as applicable
- [X] Update Changelog
- [ ] Integration tests are passing
- [x] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
