### PR TITLE
(NEXMANAGE-1272) Always add /var/intel-manageability directory for SQLITE3 DB

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## X.X.X - YYYY-MM-DD
 ### Changed
+- (NEXMANAGE-1272) Fix /var/intel-manageability directory not being created when using LUKS which is needed for sqlite3
 - (NEXMANAGE-956) Improve failure reason from TC that is logged in Mjunct DB for FOTA
 - (NEXMANAGE-1194) provision-tc/mqtt services will now handle UDM
 - (NEXMANAGE-1253) Implement INBS (UDM) decommission command, which removes device credentials

--- a/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-secret-mounted
+++ b/inbm/fpm/mqtt/template/usr/bin/mqtt-ensure-secret-mounted
@@ -22,6 +22,9 @@ if mountpoint -q "/mnt/udm-luks" ; then
     # Ensure public directory exists
     mkdir -p "$TC_PUBLIC"
 
+    # Ensure this directory exists as it is also used for SQLITE3 DB
+    mkdir -p "$TC_SECRET_IMG_DIR"
+
     # Exit the script since we've completed the necessary steps for UDM mode
     exit 0
 fi


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

/var/intel-manageability directory is required for SQLITE3.  It was not getting created when using LUKS instead of the intel secret.  This also creates the directory when LUKS is used.


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Using LUKS was bypassing creating the /var/intel-manageability directory which is required for sqlite3 |
| Jira ticket | NEXMANAGE-1272 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
