### PR TITLE
[NEXMANAGE-1284] Timed out waiting for INBM Dispatcher response after trigger first run for power heuristic operation

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - (NEXMANAGE-1280) Software Update Release Date and URL should not be required in common.proto
+- (NEXMANAGE-1284) Timed out waiting for INBM Dispatcher response after trigger first run for power heuristic operation
 
 ### Added
 - (NEXMANAGE-1222) Add support for Ubuntu 24.04

--- a/inbm/dispatcher-agent/dispatcher/dispatcher_broker.py
+++ b/inbm/dispatcher-agent/dispatcher/dispatcher_broker.py
@@ -85,17 +85,18 @@ class DispatcherBroker:
 
         schedule = self._check_db_for_started_job()
         logger.debug(f"Schedule in Broker Send_result: {schedule}")
-        
-        if not schedule:
-            # This is not a scheduled job
-            logger.debug(f"Sending result message with id {request_id}: {message}")
-            if request_id != "":
-                topic = RESPONSE_CHANNEL + "/" + request_id
-                self.mqtt_publish(topic=topic, payload=message)
-            else:
-                self.mqtt_publish(topic=RESPONSE_CHANNEL, payload=message)
+
+        if request_id != "":
+            # This is a response to a specific request ID -- unrelated to scheduling
+            logger.debug(f"Sending result message with id {request_id}: {message}")                    
+            topic = RESPONSE_CHANNEL + "/" + request_id
+            self.mqtt_publish(topic=topic, payload=message)
+        elif not schedule:
+            # This is not a scheduled job (and no request ID)
+            logger.debug(f"Sending result message: {message}")
+            self.mqtt_publish(topic=RESPONSE_CHANNEL, payload=message)
         else:
-            # This is a scheduled job 
+            # This is a scheduled job (and no request ID)
             
             # TODO: add error handling NEXMANAGE-743
                        


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

This bug is the result of a coding mistake which tries to look up schedule info when responding to a request with a request ID. Scheduling info is only relevant when sending a result WITHOUT a request ID.

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | reusing same method for different tasks|
| Jira ticket | NEXMANAGE-1284 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [x] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
