### PR TITLE
Add granular log support

### DIFF
--- a/cmd/inbd/main.go
+++ b/cmd/inbd/main.go
@@ -21,6 +21,8 @@ func main() {
 	socket := flag.String("s", "/var/run/inbd.sock", "UNIX domain socket path")
 	flag.Parse()
 
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
 	// Build our dependency struct using real functions.
 	deps := inbd.ServerDeps{
 		Socket:        *socket,

--- a/internal/os_updater/snapshot.go
+++ b/internal/os_updater/snapshot.go
@@ -200,7 +200,10 @@ func VerifyUpdateAfterReboot(osType string) error {
 				if err != nil {
 					log.Printf("[Warning] Error writing update status: %v", err)
 				}
-
+				err = writeGranularLog(FAIL, FAILURE_REASON_BOOTLOADER)
+				if err != nil {
+					log.Printf("[Warning] Error writing granular log: %v", err)
+				}
 				log.Println("Rebooting...")
 				// Reboot the system without commit.
 				// //TODO: Only reboot here? Or should we also reboot without commit in other failure?
@@ -225,8 +228,10 @@ func VerifyUpdateAfterReboot(osType string) error {
 
 			log.Println("SUCCESSFUL INSTALL: Overall SOTA update successful.  System has been properly updated.")
 
-			// TODO: Write the granular log for success and fail cases.
-
+			err = writeGranularLog(SUCCESS, "")
+			if err != nil {
+				log.Printf("[Warning] Error writing granular log: %v", err)
+			}
 		}
 
 	} else {


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

This PR adds the support for recording the granular log.
NOTE: criticalservices failure is not implemented as other services are removed (diagnostic,configuration...etc).

List of granular logs:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Name | Descriptions | Content   of granular log
-- | -- | --
Unspecified | When   update failed but any of the below reasons apply | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "unspecified"           }       ]   }
Download | Artifact   download failed | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "download"           }       ]   }
InsufficientStorage | Disk   check returns insufficient storage error | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "insufficientstorage"           }       ]   }
RSAuthentication | Release   Service authentication error | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "rsauthentication"           }       ]   }
SignatureCheck | Downloaded   image signature check error | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "signaturecheck"           }       ]   }
Write | Writing   image to secondary partition error | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "utwrite"           }       ]   }
BootConfiguration | Boot   configuration update error | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "utbootconfiguration"           }       ]   }
Bootloader | Post   update check - bootloader failed to boot from the correct partition | {       "UpdateLog": [           {               "StatusDetail.Status":   "ROLLBACK",               "FailureReason":   "bootloader"           }       ]   }
CriticalServices | Post   update check - critical services start failure | {       "UpdateLog": [           {               "StatusDetail.Status":   "ROLLBACK",               "FailureReason":   "criticalservices"           }       ]   }
INBM | INBM   failure | {       "UpdateLog": [           {               "StatusDetail.Status":   "FAIL",               "FailureReason":   "inbm"           }       ]   }
OSCommit | Setting   the current partition as primary failure | {       "UpdateLog": [           {               "StatusDetail.Status":   "ROLLBACK",               "FailureReason":   "oscommit"           }       ]   }



</div>

<!--EndFragment-->
</body>

</html>


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Specifically for bugs, empty in case of no variants |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [ ] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
