### PR TITLE
(NEXMANAGE-1263) Re-enable enforcement of TLS mode when sending token to INBS cloud

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## X.X.X - YYYY-MM-DD
 ### Fixed
 - (ITEP-23994) Support non-auth RS
+- (NEXMANAGE-1263) Re-enable enforcement of TLS mode when sending token to INBS cloud
 
 ## 4.2.8.5 - 2025-03-17
 ### Changed

--- a/inbm/cloudadapter-agent/cloudadapter/cloud/client/inbs_cloud_client.py
+++ b/inbm/cloudadapter-agent/cloudadapter/cloud/client/inbs_cloud_client.py
@@ -65,14 +65,12 @@ class InbsCloudClient(CloudClient):
 
         self._metadata: list[tuple[str, str]] = [("node-id", node_id)]
 
-        # this code will be used when TLS is available in INBS
-        # if tls_enabled:
-        #     if token is None:
-        #         raise AuthenticationError("Token is required when TLS is enabled.")
-        #     else:
-        #         self._metadata.append(("authorization", "Bearer " + token))
-        #     # if tls_cert is None, this is OK; implied that we have it installed system wide
-        # instead, we will simply use the token if it exists
+        if tls_enabled:
+            if token is None:
+                raise AuthenticationError("Token is required when TLS is enabled.")
+            else:
+                self._metadata.append(("authorization", "Bearer " + token))
+            # if tls_cert is None, this is OK; implied that we have it installed system wide
 
         if token is not None:
             self._metadata.append(("authorization", "Bearer " + token))


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

Re-enable enforcement of TLS mode when sending token to INBS cloud


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | Enforcement was removed for demo and not reenabled. |
| Jira ticket | NEXMANAGE-1263 |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [x] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
