### PR TITLE
Update Golang Version from 1.22 to 1.24 for CVEs

### DIFF
--- a/docker-compose-dev/Dockerfile.diagnostic
+++ b/docker-compose-dev/Dockerfile.diagnostic
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /go/src/app
 COPY inbm/trtl .

--- a/docker-compose-dev/Dockerfile.dispatcher
+++ b/docker-compose-dev/Dockerfile.dispatcher
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /go/src/app
 COPY inbm/trtl .

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## X.X.X - YYYY-MM-DD
 
 ### Security
-- (N/A) Update Golang Version from 22.04 to 24.04 to resolve CVEs: 
+- (N/A) Update Golang Version from 22.04 to 24.04 to resolve CVE: CVE-2025-22870
 
 ## 4.2.8.6 - 2025-04-03
 ### Fixed

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## X.X.X - YYYY-MM-DD
 
+### Security
+- (N/A) Update Golang Version from 22.04 to 24.04 to resolve CVEs: 
+
 ## 4.2.8.6 - 2025-04-03
 ### Fixed
 - (ITEP-23994) Support non-auth RS

--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## X.X.X - YYYY-MM-DD
 
 ### Security
-- (N/A) Update Golang Version from 22.04 to 24.04 to resolve CVE: CVE-2025-22870
+- (N/A) Update Golang Version from 1.22 to 1.24 to resolve CVE: CVE-2025-22870
 
 ## 4.2.8.6 - 2025-04-03
 ### Fixed

--- a/inbm/dockerfiles/Dockerfile-Windows.m4
+++ b/inbm/dockerfiles/Dockerfile-Windows.m4
@@ -58,17 +58,17 @@ RUN mkdir -p /output && \
 RUN pyinstaller inbm-cloudadapter-windows.spec && \
     cp -r ../cloudadapter-agent/dist/inbm-cloudadapter /output
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-certs-windows
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-certs-windows
 COPY inbm/fpm/inb-provision-certs /inb-provision-certs
 RUN cd /inb-provision-certs && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-certs/inb-provision-certs.exe /output/inb-provision-certs.exe
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-cloud-windows
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-cloud-windows
 COPY inbm/fpm/inb-provision-cloud /inb-provision-cloud
 RUN cd /inb-provision-cloud && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-cloud/inb-provision-cloud.exe /output/inb-provision-cloud.exe
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-ota-cert-windows
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-ota-cert-windows
 COPY inbm/fpm/inb-provision-ota-cert /inb-provision-ota-cert
 RUN cd /inb-provision-ota-cert && GOOS=windows GOARCH=386 CGO_ENABLED=0 go build . && \
     rm -rf /output/ && mkdir /output && cp /inb-provision-ota-cert/inb-provision-ota-cert.exe /output/inb-provision-ota-cert.exe

--- a/inbm/dockerfiles/image.main.m4
+++ b/inbm/dockerfiles/image.main.m4
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # base image with all dependencies for building
-FROM registry.hub.docker.com/library/ubuntu:20.04 AS base
+FROM registry.hub.docker.com/library/ubuntu:22.04 AS base
 RUN echo 'force cache refresh 20240212'
 include(`commands.base-setup.m4')
 
@@ -153,7 +153,7 @@ RUN source /venv-py3/bin/activate && \
 
 # ---trtl---
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS trtl-build
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS trtl-build
 WORKDIR /
 ENV GOPATH /build/go
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
@@ -181,19 +181,19 @@ RUN rm -rf /output/ && mv ./output/ /output/
 
 # --inb-provision-certs-
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-certs
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-certs
 COPY inbm/fpm/inb-provision-certs /inb-provision-certs
 RUN cd /inb-provision-certs && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-certs/inb-provision-certs /output/inb-provision-certs
 
 # --inb-provision-cloud-
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-cloud
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-cloud
 COPY inbm/fpm/inb-provision-cloud /inb-provision-cloud
 RUN cd /inb-provision-cloud && go test . && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-cloud/inb-provision-cloud /output/inb-provision-cloud
 
 # --inb-provision-ota-cert-
 
-FROM registry.hub.docker.com/library/golang:1.22-bookworm AS inb-provision-ota-cert
+FROM registry.hub.docker.com/library/golang:1.24-bookworm AS inb-provision-ota-cert
 COPY inbm/fpm/inb-provision-ota-cert /inb-provision-ota-cert
 RUN cd /inb-provision-ota-cert && CGO_ENABLED=0 go build -trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="all=-s -w" . &&  rm -rf /output/ && mkdir /output && cp /inb-provision-ota-cert/inb-provision-ota-cert /output/inb-provision-ota-cert
 
@@ -240,7 +240,7 @@ RUN make build && \
     mv output/* /output
 
 # output container
-FROM registry.hub.docker.com/library/ubuntu:20.04 AS output-main
+FROM registry.hub.docker.com/library/ubuntu:22.04 AS output-main
 COPY --from=packaging /output /packaging
 COPY --from=inbc-py3 /output /inbc
 COPY --from=diagnostic-py3 /output /diagnostic

--- a/inbm/dockerfiles/image.main.m4
+++ b/inbm/dockerfiles/image.main.m4
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # base image with all dependencies for building
-FROM registry.hub.docker.com/library/ubuntu:22.04 AS base
+FROM registry.hub.docker.com/library/ubuntu:20.04 AS base
 RUN echo 'force cache refresh 20240212'
 include(`commands.base-setup.m4')
 
@@ -240,7 +240,7 @@ RUN make build && \
     mv output/* /output
 
 # output container
-FROM registry.hub.docker.com/library/ubuntu:22.04 AS output-main
+FROM registry.hub.docker.com/library/ubuntu:20.04 AS output-main
 COPY --from=packaging /output /packaging
 COPY --from=inbc-py3 /output /inbc
 COPY --from=diagnostic-py3 /output /diagnostic


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

Updates Golang Version from 1.22 to 1.24 to resolve CVE: CVE-2025-22870


### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Jira ticket | Add the name to the Jira ticket eg: "NEXMANAGE-622". Automation will do the linking to Jira |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
