### PR TITLE
Fix TPM removal issue during build

### DIFF
--- a/inbm/Changelog.md
+++ b/inbm/Changelog.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## X.X.X - YYYY-MM-DD
+### Changed
+- (N/A) Fix tpm container removal issue during build
 
 ### Security
 - (N/A) Update Golang Version from 1.22 to 1.24 to resolve CVE: CVE-2025-22870

--- a/inbm/tpm2-simulator/build.sh
+++ b/inbm/tpm2-simulator/build.sh
@@ -21,4 +21,4 @@ docker run -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name tpm2-tools
 rm -rf debs*
 docker cp 'tpm2-tools-output:/debs-20.04' ./debs-20.04/
 [ -f debs-20.04/*simulator*deb ]
-docker rm tpm2-tools-output
+docker rm -f tpm2-tools-output


### PR DESCRIPTION

<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION

During INBM package build stage, it fails with an error when attempting to remove the tpm2-tool-output container. The fix proposed in the PR is to add the -f option to force remove the container.

![image](https://github.com/user-attachments/assets/e55ced35-8408-4015-8879-ddc5c9b8af70)

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | tpm2-tool-output fails to remove. |
| Jira ticket | - |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [x] Update Changelog
- [ ] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
