### PR TITLE
resolve daemon warnings for threading methods

### DIFF
--- a/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
+++ b/inbm/dispatcher-agent/dispatcher/dispatcher_class.py
@@ -190,7 +190,7 @@ class Dispatcher:
             if not self.update_queue.empty():
                 if active_count() - active_start_count < self._thread_count:
                     worker = Thread(target=handle_updates, args=(self,))
-                    worker.setDaemon(True)
+                    worker.daemon = True
                     self._thread_list.append(worker)
                     worker.start()
 

--- a/inbm/dispatcher-agent/dispatcher/workload_orchestration.py
+++ b/inbm/dispatcher-agent/dispatcher/workload_orchestration.py
@@ -72,7 +72,7 @@ class WorkloadOrchestration:
         if self.is_workload_service_file_present():
             if online_mode:
                 worker = Thread(target=self._switch_to_online_mode)
-                worker.setDaemon(True)
+                worker.daemon = True
                 worker.start()
             elif self.is_workload_service_active():
                 self._switch_to_maintenance_mode()

--- a/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
+++ b/inbm/dispatcher-agent/tests/unit/sota/test_cancel.py
@@ -30,7 +30,7 @@ class TestCancelThread(unittest.TestCase):
         type_of_manifest = "ota"
         thread_list = []
         worker = threading.Thread(target=mock_thread, args=(cancel_event,))
-        worker.setDaemon(True)
+        worker.daemon = True
         thread_list.append(worker)
         worker.start()
         sleep(1)
@@ -65,7 +65,7 @@ class TestCancelThread(unittest.TestCase):
         type_of_manifest = "ota"
         thread_list = []
         worker = threading.Thread(target=mock_thread, args=(cancel_event,))
-        worker.setDaemon(True)
+        worker.daemon = True
         thread_list.append(worker)
         worker.start()
         sleep(1)
@@ -104,7 +104,7 @@ class TestCancelThread(unittest.TestCase):
         type_of_manifest = "ota"
         thread_list = []
         worker = threading.Thread(target=mock_thread, args=(cancel_event,))
-        worker.setDaemon(True)
+        worker.daemon = True
         thread_list.append(worker)
         worker.start()
         sleep(1)

--- a/inbm/telemetry-agent/telemetry/poller.py
+++ b/inbm/telemetry-agent/telemetry/poller.py
@@ -148,7 +148,7 @@ class Poller(IPoller):
                 if self._rm_active and not self.pms_notification_registered:
                     pms = pms_notification.PMSNotification(client)
                     worker = Thread(target=pms.register_pms_notification, args=(self,))
-                    worker.setDaemon(True)
+                    worker.daemon = True
                     worker.start()
                     self.previous_rm_active_status = True
                 elif self.previous_rm_active_status and not self._rm_active:


### PR DESCRIPTION
<!---
  SPDX-FileCopyrightText: Copyright (C) 2017-2024 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable for the PR change.
-->

### PULL DESCRIPTION
This PR resolves the `threading` deprecation warnings I'm getting when running this project. The warnnings are:
```python
DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead pa.setDaemon(True)
```

### Impact Analysis

| Info | Please fill out this column |
| ------ | ----------- |
| Root Cause | deprecation warnings |
| Jira ticket |  |


### CODE MAINTAINABILITY

- [ ] Added required new tests relevant to the changes
- [ ] Updated Documentation as relevant to the changes
- [ ] PR change contains code related to security
- [ ] PR introduces changes that break compatibility with other modules/services (If YES, please provide description)
- [ ] Run `go fmt` or `format-python.sh` as applicable
- [ ] Update Changelog
- [x] Integration tests are passing
- [ ] If Cloudadapter changes, check Azure connectivity manually

# _Code must act as a teacher for future developers_
